### PR TITLE
Improve Ascend CI case diff scanner coverage extraction

### DIFF
--- a/.agent/skills/ascend-ci-case-diff-scan/README.md
+++ b/.agent/skills/ascend-ci-case-diff-scan/README.md
@@ -21,9 +21,10 @@ This skill statically audits a target `verl` repository and reports workflow/cas
 
 - `pytest` means UT
 - UT entries are expanded to concrete test functions or test methods whenever the target Python file can be parsed
-- `torchrun` and `bash tests/*.sh` mean ST
+- `torchrun`, `bash tests/*.sh`, and `bash examples/*.sh` mean ST
 - Repeated commands are kept distinct by `workflow name`, `job name`, and `step name`
 - Use `--repo-root` to point at the target `verl` repository root
+- The scanner reads workflow `run:` commands directly and records only the scripts explicitly invoked by each step
 
 ## Output
 

--- a/.agent/skills/ascend-ci-case-diff-scan/README.md
+++ b/.agent/skills/ascend-ci-case-diff-scan/README.md
@@ -8,7 +8,7 @@ This skill statically audits a target `verl` repository and reports workflow/cas
 - Pairs CPU/GPU workflows with their NPU counterparts
 - Counts UT cases at the test-function or test-method level
 - Counts ST cases at the command level
-- Writes an English `report.md`
+- Writes English `report.md` and `report.xlsx` files
 
 ## Workflow pairing
 
@@ -27,7 +27,7 @@ This skill statically audits a target `verl` repository and reports workflow/cas
 
 ## Output
 
-The report includes:
+The reports include:
 
 - ignored workflows
 - scanned workflows with CPU/GPU and NPU case counts
@@ -35,3 +35,5 @@ The report includes:
 - ST details
 
 Within UT and ST sections, the report shows matched, CPU/GPU-only, NPU-only, and manual-review cases in that order, with adjacent CPU/GPU and NPU references for easy comparison.
+
+The Excel workbook contains four sheets: `Ignored Workflows`, `Scanned Workflows`, `UT Cases`, and `ST Cases`.

--- a/.agent/skills/ascend-ci-case-diff-scan/README.md
+++ b/.agent/skills/ascend-ci-case-diff-scan/README.md
@@ -4,8 +4,7 @@ This skill statically audits a target `verl` repository and reports workflow/cas
 
 ## What it does
 
-- Excludes non-test workflows through `config/workflow_scope.json`
-- Excludes `cpu_unit_tests.yml` from the scan because it is treated as shared baseline coverage rather than an NPU-adapted workflow
+- Excludes non-test and non-comparable workflows through `config/workflow_scope.json`
 - Pairs CPU/GPU workflows with their NPU counterparts
 - Counts UT cases at the test-function or test-method level
 - Counts ST cases at the command level

--- a/.agent/skills/ascend-ci-case-diff-scan/SKILL.md
+++ b/.agent/skills/ascend-ci-case-diff-scan/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ascend-ci-case-diff-scan
-description: Scan an external verl repository for Ascend/NPU CI coverage gaps by comparing CPU/GPU workflow cases against NPU workflows. Use when Codex needs to audit workflow and case-level parity or generate a Markdown report about workflow execution differences.
+description: Scan an external verl repository for Ascend/NPU CI coverage gaps by comparing CPU/GPU workflow cases against NPU workflows. Use when Codex needs to audit workflow and case-level parity or generate Markdown and Excel reports about workflow execution differences.
 ---
 
 # Ascend CI Case Diff Scan
@@ -9,9 +9,9 @@ Audit Ascend CI coverage in a target `verl` repository with the scanner shipped 
 
 ## Overview
 
-Use this skill when you need to compare CPU/GPU workflow test coverage with NPU workflow coverage and produce an English Markdown report. The scanner is static: it reads GitHub Actions workflow `run:` commands, preserves workflow/job/step context, and does not execute tests.
+Use this skill when you need to compare CPU/GPU workflow test coverage with NPU workflow coverage and produce English Markdown and Excel reports. The scanner is static: it reads GitHub Actions workflow `run:` commands, preserves workflow/job/step context, and does not execute tests.
 
-The report shows ignored workflows, paired CPU/GPU and NPU workflows, UT/ST case counts, matched cases, missing cases, NPU-only cases, and manual-review cases.
+The reports show ignored workflows, paired CPU/GPU and NPU workflows, UT/ST case counts, matched cases, missing cases, NPU-only cases, and manual-review cases.
 
 ## Instructions
 
@@ -73,13 +73,13 @@ Treat matching conservatively:
 
 ## Reporting
 
-The scanner writes `report.md` to the requested output directory.
+The scanner writes `report.md` and `report.xlsx` to the requested output directory.
 
-The report contains:
+The reports contain:
 
 - ignored workflows
 - scanned workflows with CPU/GPU and NPU case counts
 - UT details
 - ST details
 
-Within the UT and ST sections, matched, CPU/GPU-only, NPU-only, and manual-review cases are shown in that order, with CPU/GPU and NPU references adjacent for easier comparison.
+Within the UT and ST sections, matched, CPU/GPU-only, NPU-only, and manual-review cases are shown in that order, with CPU/GPU and NPU references adjacent for easier comparison. The Excel workbook stores these sections as four sheets: `Ignored Workflows`, `Scanned Workflows`, `UT Cases`, and `ST Cases`.

--- a/.agent/skills/ascend-ci-case-diff-scan/SKILL.md
+++ b/.agent/skills/ascend-ci-case-diff-scan/SKILL.md
@@ -5,33 +5,19 @@ description: Scan an external verl repository for Ascend/NPU CI coverage gaps by
 
 # Ascend CI Case Diff Scan
 
-Use this skill from the current repository to audit Ascend CI coverage in a target `verl` repository.
+Audit Ascend CI coverage in a target `verl` repository with the scanner shipped in this skill.
 
 ## Overview
 
-The scanner performs a static analysis of workflow files and reports:
+Use this skill when you need to compare CPU/GPU workflow test coverage with NPU workflow coverage and produce an English Markdown report. The scanner is static: it reads GitHub Actions workflow `run:` commands, preserves workflow/job/step context, and does not execute tests.
 
-1. Which workflows are out of scope and excluded by configuration.
-2. Which CPU/GPU workflows are paired with NPU workflows.
-3. How many function-level UT cases and command-level ST cases each workflow contributes.
-4. Which cases are matched, missing, NPU-only, or need manual review.
+The report shows ignored workflows, paired CPU/GPU and NPU workflows, UT/ST case counts, matched cases, missing cases, NPU-only cases, and manual-review cases.
 
-## Scope
+## Instructions
 
-The scanner reads workflow `run:` commands as the source of truth.
-
-- Ignore `examples/**`.
-- Ignore commented workflow lines.
-- Ignore `cpu_unit_tests.yml` because it is treated as shared CPU/GPU/NPU baseline coverage, not an NPU-adaptation target.
-- Do not execute tests.
-- Do not expand GitHub Actions matrices.
-- Keep the final report in English only.
-
-## Workflow
-
-1. Read [references/repo-signals.md](./references/repo-signals.md) to refresh repo-specific boundaries.
+1. Read [references/repo-signals.md](./references/repo-signals.md) for repo-specific boundaries.
 2. Identify the target `verl` repository root, for example `{PATH}/verl`.
-3. Run the scanner from the current repository:
+3. Run the scanner from this repository:
 
 ```shell
 python .agent/skills/ascend-ci-case-diff-scan/scripts/scan_ascend_ci_case_diff.py \
@@ -45,6 +31,7 @@ Recognize only workflow commands that visibly execute tests:
 
 - `pytest ... tests/...`
 - `bash tests/.../*.sh`
+- `bash examples/.../*.sh`
 - `torchrun ... tests/...`
 
 For each extracted case, preserve:
@@ -59,6 +46,15 @@ For each extracted case, preserve:
 
 When the same command is repeated, keep cases distinct by `workflow_name`, `job_name`, and `step_name`.
 For UT expansion, treat Python test functions and `Test*::test_*` methods as the reporting unit whenever the target file can be parsed.
+For ST scripts, record only scripts explicitly invoked by the workflow step; do not inspect the script body for nested commands.
+
+## Boundaries
+
+- Ignore commented workflow lines.
+- Ignore `cpu_unit_tests.yml` because it is treated as shared CPU/GPU/NPU baseline coverage, not an NPU-adaptation target.
+- Do not execute tests.
+- Do not expand GitHub Actions matrices.
+- Keep the final report in English only.
 
 ## Classification Rules
 

--- a/.agent/skills/ascend-ci-case-diff-scan/SKILL.md
+++ b/.agent/skills/ascend-ci-case-diff-scan/SKILL.md
@@ -51,7 +51,7 @@ For ST scripts, record only scripts explicitly invoked by the workflow step; do 
 ## Boundaries
 
 - Ignore commented workflow lines.
-- Ignore `cpu_unit_tests.yml` because it is treated as shared CPU/GPU/NPU baseline coverage, not an NPU-adaptation target.
+- Ignore workflows matched by `config/workflow_scope.json`, including shared baseline and workflows without meaningful CPU/GPU-vs-NPU test coverage.
 - Do not execute tests.
 - Do not expand GitHub Actions matrices.
 - Keep the final report in English only.

--- a/.agent/skills/ascend-ci-case-diff-scan/config/workflow_scope.json
+++ b/.agent/skills/ascend-ci-case-diff-scan/config/workflow_scope.json
@@ -9,6 +9,7 @@
     "sanity.yml",
     "scorecard.yml",
     "secrets_scan.yml",
-    "type-coverage-check.yml"
+    "type-coverage-check.yml",
+    "e2e_ppo_trainer.yml"
   ]
 }

--- a/.agent/skills/ascend-ci-case-diff-scan/references/repo-signals.md
+++ b/.agent/skills/ascend-ci-case-diff-scan/references/repo-signals.md
@@ -35,6 +35,7 @@ Recognize only workflow commands that visibly execute tests:
 
 - `pytest ... tests/...`
 - `bash tests/.../*.sh`
+- `bash examples/.../*.sh`
 - `torchrun ... tests/...`
 
 ## Matching expectations

--- a/.agent/skills/ascend-ci-case-diff-scan/references/repo-signals.md
+++ b/.agent/skills/ascend-ci-case-diff-scan/references/repo-signals.md
@@ -8,7 +8,7 @@ Use these target-repo facts when running `ascend-ci-case-diff-scan` against an e
 
 ## Workflow scope
 
-Exclude workflows that are not part of CPU/GPU/NPU test coverage. The default ignored set is maintained in `config/workflow_scope.json`.
+Exclude workflows that are not part of meaningful CPU/GPU-vs-NPU test coverage. The default ignored set is maintained in `config/workflow_scope.json`.
 
 Examples:
 
@@ -16,6 +16,7 @@ Examples:
 - `cpu_unit_tests.yml`
 - `doc.yml`
 - `docker-*.yml`
+- `e2e_ppo_trainer.yml`
 - `pre-commit.yml`
 - `precommit-autofix.yml`
 - `sanity.yml`

--- a/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/excel.py
+++ b/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/excel.py
@@ -205,14 +205,23 @@ def _workbook_namespace_attrs() -> str:
 def _styles_xml() -> str:
     return """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
-<fonts count="1"><font><sz val="11"/><name val="Calibri"/></font></fonts>
-<fills count="1"><fill><patternFill patternType="none"/></fill></fills>
+<fonts count="2">
+<font><sz val="11"/><name val="Calibri"/></font>
+<font><b/><sz val="11"/><name val="Calibri"/></font>
+</fonts>
+<fills count="3">
+<fill><patternFill patternType="none"/></fill>
+<fill><patternFill patternType="gray125"/></fill>
+<fill><patternFill patternType="solid"><fgColor rgb="FFD9D9D9"/><bgColor indexed="64"/></patternFill></fill>
+</fills>
 <borders count="1"><border><left/><right/><top/><bottom/><diagonal/></border></borders>
 <cellStyleXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0"/></cellStyleXfs>
-<cellXfs count="2">
+<cellXfs count="3">
 <xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0"/>
 <xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0" applyAlignment="1">
 <alignment wrapText="1" vertical="top"/></xf>
+<xf numFmtId="0" fontId="1" fillId="2" borderId="0" xfId="0" applyFont="1" applyFill="1"
+applyAlignment="1"><alignment wrapText="1" vertical="top"/></xf>
 </cellXfs>
 </styleSheet>"""
 
@@ -240,10 +249,11 @@ def _row_xml(row_index: int, row: list[object]) -> str:
 
 def _cell_xml(row_index: int, column_index: int, value: object) -> str:
     cell_ref = f"{_column_name(column_index)}{row_index}"
+    style_id = 2 if row_index == 1 else 1
     if isinstance(value, int):
-        return f'<c r="{cell_ref}" s="1"><v>{value}</v></c>'
+        return f'<c r="{cell_ref}" s="{style_id}"><v>{value}</v></c>'
     text = _xml_text(str(value)) if value is not None else ""
-    return f'<c r="{cell_ref}" s="1" t="inlineStr"><is><t>{text}</t></is></c>'
+    return f'<c r="{cell_ref}" s="{style_id}" t="inlineStr"><is><t>{text}</t></is></c>'
 
 
 def _column_name(index: int) -> str:

--- a/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/excel.py
+++ b/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/excel.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Excel report rendering for the Ascend CI case diff scanner."""
+
+from __future__ import annotations
+
+from itertools import zip_longest
+from pathlib import Path
+from xml.sax.saxutils import escape, quoteattr
+from zipfile import ZIP_DEFLATED, ZipFile
+
+DEFAULT_COLUMN_WIDTH = 18
+IGNORED_WORKFLOW_WIDTHS = (70,)
+SCANNED_WORKFLOW_WIDTHS = (90, 22, 26)
+CASE_DETAIL_WIDTHS = (64, 16, 52, 14, 56, 88, 52, 14, 56, 88)
+CASE_STATUS_LABELS = (
+    ("matched", "Matched"),
+    ("cpu_gpu_only", "CPU/GPU Only"),
+    ("npu_only", "NPU Only"),
+    ("manual_review", "Manual Review"),
+)
+
+
+def write_excel_report(path: Path, report: dict) -> None:
+    """Write the scan report as a minimal XLSX workbook."""
+    sheets = [
+        ("Ignored Workflows", _ignored_workflow_rows(report), IGNORED_WORKFLOW_WIDTHS),
+        ("Scanned Workflows", _scanned_workflow_rows(report), SCANNED_WORKFLOW_WIDTHS),
+        ("UT Cases", _case_rows(report["ut_details"], "UT Case Name"), CASE_DETAIL_WIDTHS),
+        ("ST Cases", _case_rows(report["st_details"], "ST Case Name"), CASE_DETAIL_WIDTHS),
+    ]
+    _write_workbook(path, sheets)
+
+
+def _ignored_workflow_rows(report: dict) -> list[list[str]]:
+    rows = [["Workflow Name"]]
+    rows.extend([[path] for path in report["ignored_workflows"]])
+    return rows
+
+
+def _scanned_workflow_rows(report: dict) -> list[list[object]]:
+    rows: list[list[object]] = [["Workflow Name", "CPU/GPU Case Count", "NPU Supported Case Count"]]
+    rows.extend(
+        [
+            _excel_multiline(row["workflow_name"]),
+            row["cpu_gpu_case_count"],
+            row["npu_supported_case_count"],
+        ]
+        for row in report["scanned_workflows"]
+    )
+    return rows
+
+
+def _case_rows(details: dict, case_header: str) -> list[list[object]]:
+    rows = [
+        [
+            case_header,
+            "Match Status",
+            "CPU/GPU Workflow Name",
+            "CPU/GPU Line Number",
+            "CPU/GPU Workflow Context Name",
+            "CPU/GPU Full Raw Command",
+            "NPU Workflow Name",
+            "NPU Line Number",
+            "NPU Workflow Context Name",
+            "NPU Full Raw Command",
+        ]
+    ]
+    for section_key, status in CASE_STATUS_LABELS:
+        for item in details[section_key]:
+            rows.extend(_case_item_rows(item, status))
+    return rows
+
+
+def _case_item_rows(item: dict, status: str) -> list[list[object]]:
+    rows = []
+    cpu_gpu_refs = sorted(item["cpu_gpu_refs"], key=_ref_sort_key)
+    npu_refs = sorted(item["npu_refs"], key=_ref_sort_key)
+    for cpu_gpu_ref, npu_ref in zip_longest(cpu_gpu_refs, npu_refs):
+        rows.append([item["name"], status, *_side_cells(cpu_gpu_ref), *_side_cells(npu_ref)])
+    return rows
+
+
+def _ref_sort_key(ref: dict) -> tuple[object, ...]:
+    return ref["name"], ref["workflow_path"], ref["line_number"]
+
+
+def _side_cells(ref: dict | None) -> list[object]:
+    if not ref:
+        return ["", "", "", ""]
+    return [
+        ref["workflow_path"],
+        ref["line_number"],
+        f"{ref['workflow_name']} / {ref['job_name']} / {ref['step_name']}",
+        ref["raw_command"],
+    ]
+
+
+def _write_workbook(path: Path, sheets: list[tuple[str, list[list[object]], tuple[int, ...]]]) -> None:
+    with ZipFile(path, "w", ZIP_DEFLATED) as workbook:
+        workbook.writestr("[Content_Types].xml", _content_types_xml(len(sheets)))
+        workbook.writestr("_rels/.rels", _root_rels_xml())
+        workbook.writestr("xl/workbook.xml", _workbook_xml(sheets))
+        workbook.writestr("xl/_rels/workbook.xml.rels", _workbook_rels_xml(len(sheets)))
+        workbook.writestr("xl/styles.xml", _styles_xml())
+        for index, (_, rows, column_widths) in enumerate(sheets, start=1):
+            workbook.writestr(f"xl/worksheets/sheet{index}.xml", _worksheet_xml(rows, column_widths))
+
+
+def _content_types_xml(sheet_count: int) -> str:
+    sheet_overrides = "\n".join(
+        (
+            f'<Override PartName="/xl/worksheets/sheet{index}.xml" '
+            'ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>'
+        )
+        for index in range(1, sheet_count + 1)
+    )
+    return f"""<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+<Default Extension="xml" ContentType="application/xml"/>
+{_override_xml("/xl/workbook.xml", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml")}
+{_override_xml("/xl/styles.xml", "application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml")}
+{sheet_overrides}
+</Types>"""
+
+
+def _root_rels_xml() -> str:
+    return (
+        """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+"""
+        + _relationship_xml(
+            "rId1",
+            "http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument",
+            "xl/workbook.xml",
+        )
+        + """
+</Relationships>"""
+    )
+
+
+def _workbook_xml(sheets: list[tuple[str, list[list[object]], tuple[int, ...]]]) -> str:
+    sheet_xml = "\n".join(
+        f'<sheet name={quoteattr(name)} sheetId="{index}" r:id="rId{index}"/>'
+        for index, (name, _, _) in enumerate(sheets, start=1)
+    )
+    return f"""<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<workbook {_workbook_namespace_attrs()}>
+<sheets>
+{sheet_xml}
+</sheets>
+</workbook>"""
+
+
+def _workbook_rels_xml(sheet_count: int) -> str:
+    sheet_rels = "\n".join(
+        (
+            f'<Relationship Id="rId{index}" '
+            'Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" '
+            f'Target="worksheets/sheet{index}.xml"/>'
+        )
+        for index in range(1, sheet_count + 1)
+    )
+    style_id = sheet_count + 1
+    style_rel = _relationship_xml(
+        f"rId{style_id}",
+        "http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles",
+        "styles.xml",
+    )
+    return f"""<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+{sheet_rels}
+{style_rel}
+</Relationships>"""
+
+
+def _override_xml(part_name: str, content_type: str) -> str:
+    return f'<Override PartName="{part_name}" ContentType="{content_type}"/>'
+
+
+def _relationship_xml(relation_id: str, relation_type: str, target: str) -> str:
+    return f'<Relationship Id="{relation_id}" Type="{relation_type}" Target="{target}"/>'
+
+
+def _workbook_namespace_attrs() -> str:
+    main_xmlns = 'xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"'
+    rels_xmlns = 'xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"'
+    return f"{main_xmlns} {rels_xmlns}"
+
+
+def _styles_xml() -> str:
+    return """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+<fonts count="1"><font><sz val="11"/><name val="Calibri"/></font></fonts>
+<fills count="1"><fill><patternFill patternType="none"/></fill></fills>
+<borders count="1"><border><left/><right/><top/><bottom/><diagonal/></border></borders>
+<cellStyleXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0"/></cellStyleXfs>
+<cellXfs count="2">
+<xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0"/>
+<xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0" applyAlignment="1">
+<alignment wrapText="1" vertical="top"/></xf>
+</cellXfs>
+</styleSheet>"""
+
+
+def _worksheet_xml(rows: list[list[object]], column_widths: tuple[int, ...]) -> str:
+    max_columns = max((len(row) for row in rows), default=1)
+    column_xml = "".join(
+        f'<col min="{index}" max="{index}" width="{_column_width(index, column_widths)}" customWidth="1"/>'
+        for index in range(1, max_columns + 1)
+    )
+    row_xml = "\n".join(_row_xml(row_index, row) for row_index, row in enumerate(rows, start=1))
+    return f"""<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+<cols>{column_xml}</cols>
+<sheetData>
+{row_xml}
+</sheetData>
+</worksheet>"""
+
+
+def _row_xml(row_index: int, row: list[object]) -> str:
+    cells = "".join(_cell_xml(row_index, column_index, value) for column_index, value in enumerate(row, start=1))
+    return f'<row r="{row_index}">{cells}</row>'
+
+
+def _cell_xml(row_index: int, column_index: int, value: object) -> str:
+    cell_ref = f"{_column_name(column_index)}{row_index}"
+    if isinstance(value, int):
+        return f'<c r="{cell_ref}" s="1"><v>{value}</v></c>'
+    text = _xml_text(str(value)) if value is not None else ""
+    return f'<c r="{cell_ref}" s="1" t="inlineStr"><is><t>{text}</t></is></c>'
+
+
+def _column_name(index: int) -> str:
+    name = ""
+    while index:
+        index, remainder = divmod(index - 1, 26)
+        name = chr(65 + remainder) + name
+    return name
+
+
+def _column_width(index: int, column_widths: tuple[int, ...]) -> int:
+    if index <= len(column_widths):
+        return column_widths[index - 1]
+    return DEFAULT_COLUMN_WIDTH
+
+
+def _excel_multiline(value: str) -> str:
+    return value.replace("<br>", "\n")
+
+
+def _xml_text(value: str) -> str:
+    cleaned = "".join(character for character in value if _is_valid_xml_char(character))
+    return escape(cleaned)
+
+
+def _is_valid_xml_char(character: str) -> bool:
+    codepoint = ord(character)
+    return codepoint in (0x9, 0xA, 0xD) or 0x20 <= codepoint <= 0xD7FF or 0xE000 <= codepoint <= 0xFFFD

--- a/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/extractors.py
+++ b/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/extractors.py
@@ -100,11 +100,11 @@ def extract_torchrun_targets(tokens: list[str], torchrun_idx: int) -> list[str]:
 
 
 def extract_bash_target(tokens: list[str]) -> str | None:
-    """Extract bash-invoked test scripts when the target is an explicit tests/*.sh path."""
+    """Extract bash-invoked test scripts from explicit workflow step commands."""
     for idx, token in enumerate(tokens[:-1]):
         if token == "bash":
             target = normalize_path_text(tokens[idx + 1].strip("\"'"))
-            if target.startswith("tests/") and target.endswith(".sh"):
+            if target.startswith(("tests/", "examples/")) and target.endswith(".sh"):
                 return target
     return None
 

--- a/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/render.py
+++ b/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/render.py
@@ -79,8 +79,13 @@ def render_report(report: dict) -> str:
         "Read this report in order: Ignored Workflows, Scanned Workflows, UT Case Details, and ST Case Details.",
         "",
         (
-            "Within both UT Case Details and ST Case Details, cases are grouped into Matched Cases, "
-            "CPU/GPU-only Cases, NPU-only Cases, and Manual Review."
+            "UT cases are counted and displayed at the individual test function or test method level. "
+            "ST cases are counted and displayed at the executed test command or script level."
+        ),
+        "",
+        (
+            "Within both UT/ST detail sections, cases are grouped into Matched Cases, CPU/GPU-only Cases, "
+            "NPU-only Cases, and Manual Review."
         ),
         "",
         f"## Ignored Workflows ({len(report['ignored_workflows'])})",

--- a/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/workflows.py
+++ b/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/workflows.py
@@ -156,7 +156,47 @@ def _extract_run_entries(
         stripped = next_line[indent + 2 :] if len(next_line) >= indent + 2 else next_line.lstrip()
         run_entries.append((stripped, idx + 1))
         idx += 1
-    return run_entries, idx
+    return _merge_shell_continuations(run_entries), idx
+
+
+def _ends_with_shell_continuation(command: str) -> bool:
+    stripped = command.rstrip()
+    if not stripped.endswith("\\"):
+        return False
+    slash_count = 0
+    for char in reversed(stripped):
+        if char != "\\":
+            break
+        slash_count += 1
+    return slash_count % 2 == 1
+
+
+def _merge_shell_continuations(entries: list[tuple[str, int]]) -> list[tuple[str, int]]:
+    merged: list[tuple[str, int]] = []
+    pending_parts: list[str] = []
+    pending_line = 0
+
+    for command, line_number in entries:
+        stripped = command.strip()
+        if not stripped and not pending_parts:
+            continue
+        if not pending_parts:
+            pending_line = line_number
+        if _ends_with_shell_continuation(stripped):
+            pending_parts.append(stripped.rstrip()[:-1].rstrip())
+            continue
+        pending_parts.append(stripped)
+        merged_command = " ".join(part for part in pending_parts if part)
+        if merged_command:
+            merged.append((merged_command, pending_line))
+        pending_parts = []
+        pending_line = 0
+
+    if pending_parts:
+        merged_command = " ".join(part for part in pending_parts if part)
+        if merged_command:
+            merged.append((merged_command, pending_line))
+    return merged
 
 
 def _make_command_case(command_type: str, case_kind: str, target: str, command: str, targets: list[str]) -> dict:

--- a/.agent/skills/ascend-ci-case-diff-scan/scripts/scan_ascend_ci_case_diff.py
+++ b/.agent/skills/ascend-ci-case-diff-scan/scripts/scan_ascend_ci_case_diff.py
@@ -23,6 +23,7 @@ from pathlib import Path
 
 from modules.compare import compare_cases_by_pair, summarize_scanned_workflows
 from modules.config import ST_KIND, UT_KIND, load_config, validate_repo_root
+from modules.excel import write_excel_report
 from modules.render import render_report
 from modules.workflows import build_workflow_groups, collect_scan_data
 
@@ -39,7 +40,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--output-dir",
         required=True,
-        help="Directory where the generated report.md will be written.",
+        help="Directory where the generated report.md and report.xlsx will be written.",
     )
     return parser.parse_args()
 
@@ -65,7 +66,10 @@ def main() -> int:
     }
     report_path = output_dir / "report.md"
     report_path.write_text(render_report(report), encoding="utf-8")
+    excel_path = output_dir / "report.xlsx"
+    write_excel_report(excel_path, report)
     print(report_path)
+    print(excel_path)
     return 0
 
 


### PR DESCRIPTION
## Summary

- Fix workflow `run:` parsing so shell continuations across one or more lines are merged before extracting cases
- Include explicitly invoked `bash examples/**/*.sh` scripts as ST cases while preserving existing pytest, bash tests, and torchrun extraction
- Update skill docs and report wording to clarify scan scope, ignored workflow configuration, and UT/ST reporting granularity

## Validation

- `conda run -n dev python -m compileall -q .agent\skills\ascend-ci-case-diff-scan\scripts`
- `conda run -n dev python .agent/skills/ascend-ci-case-diff-scan/scripts/scan_ascend_ci_case_diff.py --repo-root ../verl --output-dir .`