### PR TITLE
add past-N commit reports and tighten case matching

### DIFF
--- a/.agent/skills/ascend-ci-case-diff-scan/README.md
+++ b/.agent/skills/ascend-ci-case-diff-scan/README.md
@@ -25,8 +25,11 @@ This skill statically audits a target `verl` repository and reports workflow/cas
 - Repeated commands are kept distinct by `workflow name`, `job name`, and `step name`
 - Use `--repo-root` to point at the target `verl` repository root
 - The scanner reads workflow `run:` commands directly and records only the scripts explicitly invoked by each step
-- `--since-days` enables a second report that traces the final workflow / UT / ST changes within the selected window and checks them against the current HEAD NPU support state
-- The past-N-days report keeps the same workflow-first logic as the full scan, but only surfaces workflows and cases that actually changed within the window
+- `--since-days N` enables a second report for the last `N` merged days and must be a positive integer
+- The past-N-days report keeps the same workflow-first logic as the full scan, but only surfaces CPU/GPU workflows and cases that ended up changed within the window
+- NPU workflows are used as current support evidence in the past report, not as changed-workflow rows
+- For past-N-days cases, `Related Commits` reflects commits in the selected window that touched the workflow or the changed case target
+- `bash` and `torchrun` use strict command-level signatures; `pytest` keeps execution semantics while avoiding false differences from broad discovery selectors
 
 ## Output
 
@@ -36,6 +39,13 @@ The reports include:
 - scanned workflows with CPU/GPU and NPU case counts
 - UT details
 - ST details
+
+Past-N-days reports also include:
+
+- a summary of CPU/GPU workflows that are not fully aligned with NPU
+- changed workflow rows with window-start and current-HEAD case counts
+- changed case details with signatures and related commits
+- commit details for the merged commits inside the selected window
 
 Within UT and ST sections, the report shows matched, CPU/GPU-only, NPU-only, and manual-review cases in that order, with adjacent CPU/GPU and NPU references for easy comparison.
 

--- a/.agent/skills/ascend-ci-case-diff-scan/README.md
+++ b/.agent/skills/ascend-ci-case-diff-scan/README.md
@@ -9,6 +9,7 @@ This skill statically audits a target `verl` repository and reports workflow/cas
 - Counts UT cases at the test-function or test-method level
 - Counts ST cases at the command level
 - Writes English `report.md` and `report.xlsx` files
+- Optionally writes `report-past-N.md` and `report-past-N.xlsx` for recent merged commits when `--since-days N` is set
 
 ## Workflow pairing
 
@@ -24,6 +25,8 @@ This skill statically audits a target `verl` repository and reports workflow/cas
 - Repeated commands are kept distinct by `workflow name`, `job name`, and `step name`
 - Use `--repo-root` to point at the target `verl` repository root
 - The scanner reads workflow `run:` commands directly and records only the scripts explicitly invoked by each step
+- `--since-days` enables a second report that traces the final workflow / UT / ST changes within the selected window and checks them against the current HEAD NPU support state
+- The past-N-days report keeps the same workflow-first logic as the full scan, but only surfaces workflows and cases that actually changed within the window
 
 ## Output
 
@@ -37,3 +40,5 @@ The reports include:
 Within UT and ST sections, the report shows matched, CPU/GPU-only, NPU-only, and manual-review cases in that order, with adjacent CPU/GPU and NPU references for easy comparison.
 
 The Excel workbook contains four sheets: `Ignored Workflows`, `Scanned Workflows`, `UT Cases`, and `ST Cases`.
+
+The past-N-days workbook contains summary, changed-workflow, changed-case, and commit-detail sheets.

--- a/.agent/skills/ascend-ci-case-diff-scan/SKILL.md
+++ b/.agent/skills/ascend-ci-case-diff-scan/SKILL.md
@@ -11,7 +11,7 @@ Audit Ascend CI coverage in a target `verl` repository with the scanner shipped 
 
 Use this skill when you need to compare CPU/GPU workflow test coverage with NPU workflow coverage and produce English Markdown and Excel reports. The scanner is static: it reads GitHub Actions workflow `run:` commands, preserves workflow/job/step context, and does not execute tests.
 
-The reports show ignored workflows, paired CPU/GPU and NPU workflows, UT/ST case counts, matched cases, missing cases, NPU-only cases, and manual-review cases.
+The reports show ignored workflows, paired CPU/GPU and NPU workflows, UT/ST case counts, matched cases, missing cases, NPU-only cases, and manual-review cases. When `--since-days N` is set, the scanner also emits a past-N-days report that surfaces only workflows and UT/ST cases that actually changed in the window, then checks those changes against the current HEAD NPU state.
 
 ## Instructions
 
@@ -23,6 +23,15 @@ The reports show ignored workflows, paired CPU/GPU and NPU workflows, UT/ST case
 python .agent/skills/ascend-ci-case-diff-scan/scripts/scan_ascend_ci_case_diff.py \
   --repo-root {PATH}/verl \
   --output-dir ./report/ascend-ci-case-diff-scan
+```
+
+Optional:
+
+```shell
+python .agent/skills/ascend-ci-case-diff-scan/scripts/scan_ascend_ci_case_diff.py \
+  --repo-root {PATH}/verl \
+  --output-dir ./report/ascend-ci-case-diff-scan \
+  --since-days 7
 ```
 
 ## Extraction Rules
@@ -74,6 +83,7 @@ Treat matching conservatively:
 ## Reporting
 
 The scanner writes `report.md` and `report.xlsx` to the requested output directory.
+If `--since-days` is provided, it also writes `report-past-N.md` and `report-past-N.xlsx`.
 
 The reports contain:
 

--- a/.agent/skills/ascend-ci-case-diff-scan/SKILL.md
+++ b/.agent/skills/ascend-ci-case-diff-scan/SKILL.md
@@ -11,7 +11,7 @@ Audit Ascend CI coverage in a target `verl` repository with the scanner shipped 
 
 Use this skill when you need to compare CPU/GPU workflow test coverage with NPU workflow coverage and produce English Markdown and Excel reports. The scanner is static: it reads GitHub Actions workflow `run:` commands, preserves workflow/job/step context, and does not execute tests.
 
-The reports show ignored workflows, paired CPU/GPU and NPU workflows, UT/ST case counts, matched cases, missing cases, NPU-only cases, and manual-review cases. When `--since-days N` is set, the scanner also emits a past-N-days report that surfaces only workflows and UT/ST cases that actually changed in the window, then checks those changes against the current HEAD NPU state.
+The full reports show ignored workflows, paired CPU/GPU and NPU workflows, UT/ST case counts, matched cases, missing cases, NPU-only cases, and manual-review cases. When `--since-days N` is set, the scanner also emits a past-N-days report that surfaces only CPU/GPU workflows and UT/ST cases with effective changes in the selected window, then checks those changed cases against the current HEAD NPU support evidence.
 
 ## Instructions
 
@@ -33,6 +33,8 @@ python .agent/skills/ascend-ci-case-diff-scan/scripts/scan_ascend_ci_case_diff.p
   --output-dir ./report/ascend-ci-case-diff-scan \
   --since-days 7
 ```
+
+`--since-days` must be a positive integer. If it is omitted, only the full report is generated.
 
 ## Extraction Rules
 
@@ -56,6 +58,29 @@ For each extracted case, preserve:
 When the same command is repeated, keep cases distinct by `workflow_name`, `job_name`, and `step_name`.
 For UT expansion, treat Python test functions and `Test*::test_*` methods as the reporting unit whenever the target file can be parsed.
 For ST scripts, record only scripts explicitly invoked by the workflow step; do not inspect the script body for nested commands.
+
+Case matching uses `command_type`, `target`, and `signature`.
+
+- `bash` and `torchrun` signatures are strict command-level signatures. Environment assignments and command arguments are part of the test semantics.
+- `pytest` signatures keep execution semantics while avoiding false differences from broad discovery selectors. Function-level UT alignment is decided from the expanded concrete test path plus the retained execution signature.
+- Same target with a materially different retained signature is not treated as aligned.
+
+## Past-N-Days Analysis
+
+When `--since-days N` is set, the scanner:
+
+- walks the current branch first-parent history for commits merged in the last `N` days
+- compares the window-start snapshot with current `HEAD`
+- keeps only effective final-state changes, so additions that were later removed or reverted are not reported as changed cases
+- starts from CPU/GPU workflows and their referenced UT/ST cases, matching the full-scan workflow-first model
+- uses NPU workflows only as current `HEAD` support evidence, not as rows in `Changed Workflows`
+
+The past report columns should be read as:
+
+- `Window Start Case Count`: extracted cases in that CPU/GPU workflow at the start of the window
+- `Current HEAD Case Count`: extracted cases in that CPU/GPU workflow at current `HEAD`
+- `UT/ST Not Fully Aligned with NPU Count`: changed CPU/GPU UT/ST cases whose current `HEAD` NPU status is not fully aligned, including missing and manual-review cases
+- `Related Commits`: commits in the selected window that touched the workflow or the changed case target
 
 ## Boundaries
 

--- a/.agent/skills/ascend-ci-case-diff-scan/references/repo-signals.md
+++ b/.agent/skills/ascend-ci-case-diff-scan/references/repo-signals.md
@@ -45,3 +45,11 @@ Recognize only workflow commands that visibly execute tests:
 - Same target with materially different env or argument prefixes should usually become `manual_review_needed`.
 - Repeated commands should remain distinct when they appear in different workflow, job, or step contexts.
 - For UT, prefer function-level or test-method-level comparison over file-level comparison because broad `pytest tests/...` commands and `--ignore-glob` options can hide partial support.
+
+## Past-N-days expectations
+
+- The past-N-days report is scoped to effective final-state changes between the window-start snapshot and current `HEAD`.
+- Commits that add or modify a case and are later reverted or removed in the same window should not appear as changed cases.
+- The changed-workflow table is CPU/GPU oriented. NPU workflows should appear as support references for changed CPU/GPU cases, not as primary changed workflow rows.
+- `UT/ST Not Fully Aligned with NPU Count` covers changed CPU/GPU cases whose current `HEAD` NPU state is either missing or divergent enough to require manual review.
+- Direct changes to `tests/**` or `examples/**/*.sh` are relevant only when they are reachable from an extracted workflow case.

--- a/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/compare.py
+++ b/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/compare.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2025 Bytedance Ltd. and/or its affiliates
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/compare.py
+++ b/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/compare.py
@@ -33,6 +33,7 @@ def make_ref(case: dict) -> dict:
             ("job_name", "job_name"),
             ("step_name", "step_name"),
             ("line_number", "line_number"),
+            ("signature", "signature"),
             ("raw_command", "raw_command"),
         )
     }
@@ -60,6 +61,7 @@ def summarize_scanned_workflows(
         ]
         rows.append(
             {
+                "workflow_names": sorted(workflow_names) if workflow_names else [pair_key],
                 "workflow_name": "<br>".join(sorted(workflow_names)) if workflow_names else pair_key,
                 "cpu_gpu_case_count": len(cpu_gpu_case_ids),
                 "npu_supported_case_count": len(npu_case_ids),

--- a/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/config.py
+++ b/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/config.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2025 Bytedance Ltd. and/or its affiliates
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/excel.py
+++ b/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/excel.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2025 Bytedance Ltd. and/or its affiliates
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/excel.py
+++ b/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/excel.py
@@ -291,14 +291,12 @@ def _xml_text(value: str) -> str:
 
 
 def _past_summary_rows(report: dict) -> list[list[object]]:
-    rows = [["Case Kind", "Workflow", "NPU Status", "Case Count", "Commit Count"]]
+    rows = [["CPU/GPU and NPU Not Fully Aligned Cases", "UT Gap Count", "ST Gap Count"]]
     rows.extend(
         [
-            row["case_kind"],
-            row["workflow_name"],
-            row["npu_status"],
-            row["case_count"],
-            row["commit_count"],
+            row["affected_path"],
+            row["ut_gap_count"],
+            row["st_gap_count"],
         ]
         for row in report["summary"]
     )
@@ -311,16 +309,14 @@ def _past_detail_rows(report: dict) -> list[list[object]]:
             "Commit Hash",
             "Commit Time",
             "Commit Title",
-            "Changed Files",
-            "Case Kind",
-            "Case Name",
-            "NPU Status",
-            "Workflow Name",
-            "Workflow Path",
-            "Job Name",
-            "Step Name",
+            "Effective Changed Files",
+            "Affected Path",
             "Line Number",
-            "Raw Command",
+            "Workflow Context",
+            "Source Type",
+            "Case Name",
+            "Case Kind",
+            "NPU Status",
         ]
     ]
     for row in report["details"]:
@@ -329,16 +325,14 @@ def _past_detail_rows(report: dict) -> list[list[object]]:
                 row["commit_hash"],
                 row["commit_time"],
                 row["commit_title"],
-                _excel_multiline("<br>".join(row["changed_files"])),
-                row["case_kind"],
-                row["case_name"],
-                row["npu_status"],
-                row["workflow_name"],
-                row["workflow_path"],
-                row["job_name"],
-                row["step_name"],
+                _excel_multiline("<br>".join(row["effective_changed_files"])),
+                row["affected_path"],
                 row["line_number"],
-                row["raw_command"],
+                row["workflow_context"],
+                row["source_type"],
+                row["case_name"],
+                row["case_kind"],
+                row["npu_status"],
             ]
         )
     return rows

--- a/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/excel.py
+++ b/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/excel.py
@@ -26,6 +26,8 @@ DEFAULT_COLUMN_WIDTH = 18
 IGNORED_WORKFLOW_WIDTHS = (70,)
 SCANNED_WORKFLOW_WIDTHS = (90, 22, 26)
 CASE_DETAIL_WIDTHS = (64, 16, 52, 14, 56, 88, 52, 14, 56, 88)
+PAST_SUMMARY_WIDTHS = (14, 48, 24, 12, 12)
+PAST_DETAIL_WIDTHS = (42, 24, 16, 24, 20, 52, 14, 56, 88, 26, 64, 64)
 CASE_STATUS_LABELS = (
     ("matched", "Matched"),
     ("cpu_gpu_only", "CPU/GPU Only"),
@@ -41,6 +43,15 @@ def write_excel_report(path: Path, report: dict) -> None:
         ("Scanned Workflows", _scanned_workflow_rows(report), SCANNED_WORKFLOW_WIDTHS),
         ("UT Cases", _case_rows(report["ut_details"], "UT Case Name"), CASE_DETAIL_WIDTHS),
         ("ST Cases", _case_rows(report["st_details"], "ST Case Name"), CASE_DETAIL_WIDTHS),
+    ]
+    _write_workbook(path, sheets)
+
+
+def write_past_commit_excel_report(path: Path, report: dict) -> None:
+    """Write the past-N-days report as a minimal XLSX workbook."""
+    sheets = [
+        ("Summary", _past_summary_rows(report), PAST_SUMMARY_WIDTHS),
+        ("Commit Details", _past_detail_rows(report), PAST_DETAIL_WIDTHS),
     ]
     _write_workbook(path, sheets)
 
@@ -277,6 +288,60 @@ def _excel_multiline(value: str) -> str:
 def _xml_text(value: str) -> str:
     cleaned = "".join(character for character in value if _is_valid_xml_char(character))
     return escape(cleaned)
+
+
+def _past_summary_rows(report: dict) -> list[list[object]]:
+    rows = [["Case Kind", "Workflow", "NPU Status", "Case Count", "Commit Count"]]
+    rows.extend(
+        [
+            row["case_kind"],
+            row["workflow_name"],
+            row["npu_status"],
+            row["case_count"],
+            row["commit_count"],
+        ]
+        for row in report["summary"]
+    )
+    return rows
+
+
+def _past_detail_rows(report: dict) -> list[list[object]]:
+    rows = [
+        [
+            "Commit Hash",
+            "Commit Time",
+            "Commit Title",
+            "Changed Files",
+            "Case Kind",
+            "Case Name",
+            "NPU Status",
+            "Workflow Name",
+            "Workflow Path",
+            "Job Name",
+            "Step Name",
+            "Line Number",
+            "Raw Command",
+        ]
+    ]
+    for row in report["details"]:
+        rows.append(
+            [
+                row["commit_hash"],
+                row["commit_time"],
+                row["commit_title"],
+                _excel_multiline("<br>".join(row["changed_files"])),
+                row["case_kind"],
+                row["case_name"],
+                row["npu_status"],
+                row["workflow_name"],
+                row["workflow_path"],
+                row["job_name"],
+                row["step_name"],
+                row["line_number"],
+                row["raw_command"],
+            ]
+        )
+    return rows
 
 
 def _is_valid_xml_char(character: str) -> bool:

--- a/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/excel.py
+++ b/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/excel.py
@@ -117,7 +117,7 @@ def _ref_sort_key(ref: dict) -> tuple[object, ...]:
 
 def _side_cells(ref: dict | None) -> list[object]:
     if not ref:
-        return ["", "", "", ""]
+        return ["", "", "", "", ""]
     return [
         ref["workflow_path"],
         ref["line_number"],

--- a/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/excel.py
+++ b/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/excel.py
@@ -25,10 +25,10 @@ from zipfile import ZIP_DEFLATED, ZipFile
 DEFAULT_COLUMN_WIDTH = 18
 IGNORED_WORKFLOW_WIDTHS = (70,)
 SCANNED_WORKFLOW_WIDTHS = (90, 22, 26)
-CASE_DETAIL_WIDTHS = (64, 16, 52, 14, 56, 88, 52, 14, 56, 88)
+CASE_DETAIL_WIDTHS = (64, 16, 52, 14, 56, 72, 88, 52, 14, 56, 72, 88)
 PAST_SUMMARY_WIDTHS = (42, 16, 12, 12, 12)
 PAST_WORKFLOW_WIDTHS = (48, 16, 12, 12, 12, 12, 32)
-PAST_CASE_WIDTHS = (48, 16, 46, 26, 20, 54, 18, 64, 18, 54)
+PAST_CASE_WIDTHS = (48, 16, 46, 26, 20, 54, 72, 18, 64, 18, 54)
 PAST_DETAIL_WIDTHS = (42, 24, 36, 42)
 CASE_STATUS_LABELS = (
     ("matched", "Matched"),
@@ -87,10 +87,12 @@ def _case_rows(details: dict, case_header: str) -> list[list[object]]:
             "CPU/GPU Workflow Name",
             "CPU/GPU Line Number",
             "CPU/GPU Workflow Context Name",
+            "CPU/GPU Signature",
             "CPU/GPU Full Raw Command",
             "NPU Workflow Name",
             "NPU Line Number",
             "NPU Workflow Context Name",
+            "NPU Signature",
             "NPU Full Raw Command",
         ]
     ]
@@ -120,6 +122,7 @@ def _side_cells(ref: dict | None) -> list[object]:
         ref["workflow_path"],
         ref["line_number"],
         f"{ref['workflow_name']} / {ref['job_name']} / {ref['step_name']}",
+        ref["signature"],
         ref["raw_command"],
     ]
 
@@ -345,6 +348,7 @@ def _past_case_rows(report: dict) -> list[list[object]]:
             "Target",
             "Line",
             "Workflow Context",
+            "Signature",
             "NPU Status",
             "Related Commits",
             "NPU Refs",
@@ -358,6 +362,7 @@ def _past_case_rows(report: dict) -> list[list[object]]:
             row["target"],
             row["line_number"],
             row["workflow_context"],
+            row["signature"],
             row["npu_status"],
             ", ".join(commit[:12] for commit in row["commit_hashes"]),
             _excel_multiline(

--- a/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/excel.py
+++ b/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/excel.py
@@ -310,7 +310,17 @@ def _past_summary_rows(report: dict) -> list[list[object]]:
 
 
 def _past_workflow_rows(report: dict) -> list[list[object]]:
-    rows = [["Workflow", "Change", "Base Cases", "HEAD Cases", "UT Gap", "ST Gap", "Related Commits"]]
+    rows = [
+        [
+            "Workflow",
+            "Change",
+            "Window Start Cases",
+            "Current HEAD Cases",
+            "UT Gap",
+            "ST Gap",
+            "Related Commits",
+        ]
+    ]
     rows.extend(
         [
             row["workflow_path"],

--- a/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/excel.py
+++ b/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/excel.py
@@ -298,7 +298,15 @@ def _xml_text(value: str) -> str:
 
 
 def _past_summary_rows(report: dict) -> list[list[object]]:
-    rows = [["Workflow", "UT Gap Count", "ST Gap Count", "Change Count", "Related Commits"]]
+    rows = [
+        [
+            "Workflow",
+            "UT Not Fully Aligned with NPU Count",
+            "ST Not Fully Aligned with NPU Count",
+            "Change Count",
+            "Related Commits",
+        ]
+    ]
     rows.extend(
         [
             row["workflow_path"],
@@ -319,8 +327,8 @@ def _past_workflow_rows(report: dict) -> list[list[object]]:
             "Change",
             "Window Start Cases",
             "Current HEAD Cases",
-            "UT Gap",
-            "ST Gap",
+            "UT Not Fully Aligned with NPU",
+            "ST Not Fully Aligned with NPU",
             "Related Commits",
         ]
     ]

--- a/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/excel.py
+++ b/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/excel.py
@@ -26,8 +26,10 @@ DEFAULT_COLUMN_WIDTH = 18
 IGNORED_WORKFLOW_WIDTHS = (70,)
 SCANNED_WORKFLOW_WIDTHS = (90, 22, 26)
 CASE_DETAIL_WIDTHS = (64, 16, 52, 14, 56, 88, 52, 14, 56, 88)
-PAST_SUMMARY_WIDTHS = (14, 48, 24, 12, 12)
-PAST_DETAIL_WIDTHS = (42, 24, 16, 24, 20, 52, 14, 56, 88, 26, 64, 64)
+PAST_SUMMARY_WIDTHS = (42, 16, 12, 12, 12)
+PAST_WORKFLOW_WIDTHS = (48, 16, 12, 12, 12, 12, 32)
+PAST_CASE_WIDTHS = (48, 16, 46, 26, 20, 54, 18, 64, 18, 54)
+PAST_DETAIL_WIDTHS = (42, 24, 36, 42)
 CASE_STATUS_LABELS = (
     ("matched", "Matched"),
     ("cpu_gpu_only", "CPU/GPU Only"),
@@ -51,6 +53,8 @@ def write_past_commit_excel_report(path: Path, report: dict) -> None:
     """Write the past-N-days report as a minimal XLSX workbook."""
     sheets = [
         ("Summary", _past_summary_rows(report), PAST_SUMMARY_WIDTHS),
+        ("Changed Workflows", _past_workflow_rows(report), PAST_WORKFLOW_WIDTHS),
+        ("Changed Cases", _past_case_rows(report), PAST_CASE_WIDTHS),
         ("Commit Details", _past_detail_rows(report), PAST_DETAIL_WIDTHS),
     ]
     _write_workbook(path, sheets)
@@ -291,14 +295,72 @@ def _xml_text(value: str) -> str:
 
 
 def _past_summary_rows(report: dict) -> list[list[object]]:
-    rows = [["CPU/GPU and NPU Not Fully Aligned Cases", "UT Gap Count", "ST Gap Count"]]
+    rows = [["Workflow", "UT Gap Count", "ST Gap Count", "Change Count", "Related Commits"]]
     rows.extend(
         [
-            row["affected_path"],
+            row["workflow_path"],
             row["ut_gap_count"],
             row["st_gap_count"],
+            len(row["commit_hashes"]),
+            ", ".join(commit[:12] for commit in row["commit_hashes"]),
         ]
-        for row in report["summary"]
+        for row in report["workflow_changes"]
+    )
+    return rows
+
+
+def _past_workflow_rows(report: dict) -> list[list[object]]:
+    rows = [["Workflow", "Change", "Base Cases", "HEAD Cases", "UT Gap", "ST Gap", "Related Commits"]]
+    rows.extend(
+        [
+            row["workflow_path"],
+            row["workflow_status"],
+            row["case_count_base"],
+            row["case_count_head"],
+            row["ut_gap_count"],
+            row["st_gap_count"],
+            ", ".join(commit[:12] for commit in row["commit_hashes"]),
+        ]
+        for row in report["workflow_changes"]
+    )
+    return rows
+
+
+def _past_case_rows(report: dict) -> list[list[object]]:
+    rows = [
+        [
+            "Workflow",
+            "Case Name",
+            "Kind",
+            "Target",
+            "Line",
+            "Workflow Context",
+            "NPU Status",
+            "Related Commits",
+            "NPU Refs",
+        ]
+    ]
+    rows.extend(
+        [
+            row["workflow_path"],
+            row["case_name"],
+            row["case_kind"],
+            row["target"],
+            row["line_number"],
+            row["workflow_context"],
+            row["npu_status"],
+            ", ".join(commit[:12] for commit in row["commit_hashes"]),
+            _excel_multiline(
+                "\n".join(
+                    f"{ref['workflow_name']} / {ref['job_name']} / "
+                    f"{ref['step_name']} {ref['workflow_path']}:{ref['line_number']}"
+                    for ref in row["npu_refs"]
+                )
+            )
+            if row["npu_refs"]
+            else "",
+        ]
+        for row in report["case_details"]
     )
     return rows
 
@@ -309,30 +371,16 @@ def _past_detail_rows(report: dict) -> list[list[object]]:
             "Commit Hash",
             "Commit Time",
             "Commit Title",
-            "Effective Changed Files",
-            "Affected Path",
-            "Line Number",
-            "Workflow Context",
-            "Source Type",
-            "Case Name",
-            "Case Kind",
-            "NPU Status",
+            "Affected Workflows",
         ]
     ]
-    for row in report["details"]:
+    for row in report["commit_details"]:
         rows.append(
             [
                 row["commit_hash"],
                 row["commit_time"],
                 row["commit_title"],
-                _excel_multiline("<br>".join(row["effective_changed_files"])),
-                row["affected_path"],
-                row["line_number"],
-                row["workflow_context"],
-                row["source_type"],
-                row["case_name"],
-                row["case_kind"],
-                row["npu_status"],
+                _excel_multiline("\n".join(row["affected_workflows"])),
             ]
         )
     return rows

--- a/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/extractors.py
+++ b/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/extractors.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2025 Bytedance Ltd. and/or its affiliates
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/extractors.py
+++ b/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/extractors.py
@@ -133,7 +133,20 @@ def extract_test_functions_from_file(path: Path) -> list[str]:
         module = ast.parse(load_text(path))
     except SyntaxError:
         return []
+    return extract_test_functions_from_module(module)
 
+
+def extract_test_functions_from_text(content: str) -> list[str]:
+    """Extract test names from Python source content."""
+    try:
+        module = ast.parse(content)
+    except SyntaxError:
+        return []
+    return extract_test_functions_from_module(module)
+
+
+def extract_test_functions_from_module(module: ast.Module) -> list[str]:
+    """Extract test names from a parsed Python module."""
     names: list[str] = []
     for node in module.body:
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name.startswith("test_"):

--- a/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/past_commits.py
+++ b/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/past_commits.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2025 Bytedance Ltd. and/or its affiliates
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/past_commits.py
+++ b/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/past_commits.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+# Copyright 2025 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Past-N-days commit analysis for workflow and test case changes."""
+
+from __future__ import annotations
+
+import datetime as dt
+import subprocess
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+
+from .compare import compare_cases_by_pair
+from .config import ST_KIND, UT_KIND, WorkflowConfig
+from .extractors import extract_test_functions_from_text, normalize_path_text
+from .workflows import parse_workflow_content
+
+CI_RELATED_PREFIXES = (".github/workflows/", "tests/", "examples/")
+REPORT_STATUSES = {
+    "matched": "aligned",
+    "cpu_gpu_only": "missing_in_npu_workflows",
+    "manual_review": "manual_review_needed",
+    "npu_only": "npu_only",
+}
+
+
+@dataclass(frozen=True)
+class CommitInfo:
+    commit_hash: str
+    commit_time: str
+    commit_title: str
+    changed_files: tuple[str, ...]
+
+
+def _run_git(repo_root: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+def _is_ci_related(path_text: str) -> bool:
+    normalized = normalize_path_text(path_text)
+    return normalized.startswith(CI_RELATED_PREFIXES)
+
+
+def _is_workflow_path(path_text: str) -> bool:
+    normalized = normalize_path_text(path_text)
+    return normalized.startswith(".github/workflows/") and normalized.endswith((".yml", ".yaml"))
+
+
+def _is_test_python_path(path_text: str) -> bool:
+    normalized = normalize_path_text(path_text)
+    return normalized.startswith("tests/") and normalized.endswith(".py")
+
+
+def _is_test_script_path(path_text: str) -> bool:
+    normalized = normalize_path_text(path_text)
+    return normalized.startswith(("tests/", "examples/")) and normalized.endswith(".sh")
+
+
+def list_recent_commits(repo_root: Path, since_days: int) -> list[CommitInfo]:
+    """Return commits in HEAD history during the last N days that touch CI-related paths."""
+    cutoff = (dt.datetime.now(dt.timezone.utc) - dt.timedelta(days=since_days)).isoformat()
+    output = _run_git(
+        repo_root,
+        "log",
+        "--since",
+        cutoff,
+        "--pretty=format:%H%x1f%cI%x1f%s",
+        "--name-only",
+        "--no-renames",
+        "HEAD",
+    )
+    commits: list[CommitInfo] = []
+    current_hash = ""
+    current_time = ""
+    current_title = ""
+    current_files: list[str] = []
+
+    def flush() -> None:
+        if not current_hash:
+            return
+        related_files = tuple(path for path in current_files if _is_ci_related(path))
+        if related_files:
+            commits.append(
+                CommitInfo(
+                    commit_hash=current_hash,
+                    commit_time=current_time,
+                    commit_title=current_title,
+                    changed_files=related_files,
+                )
+            )
+
+    for line in output.splitlines():
+        if not line.strip():
+            continue
+        if "\x1f" in line:
+            flush()
+            current_hash, current_time, current_title = line.split("\x1f", 2)
+            current_files = []
+            continue
+        current_files.append(normalize_path_text(line))
+    flush()
+    return commits
+
+
+def build_past_commit_report(repo_root: Path, config: WorkflowConfig, since_days: int, head_cases: list[dict]) -> dict:
+    """Build a past-N-days report using the current HEAD scan as the NPU baseline."""
+    commits = list_recent_commits(repo_root, since_days)
+    status_index = _build_head_status_index(head_cases)
+    details: list[dict] = []
+    for commit in commits:
+        cases = _collect_commit_cases(repo_root, config, commit)
+        for case in cases:
+            status, npu_refs = _lookup_npu_support(case, status_index)
+            details.append(
+                {
+                    "commit_hash": commit.commit_hash,
+                    "commit_time": commit.commit_time,
+                    "commit_title": commit.commit_title,
+                    "changed_files": tuple(commit.changed_files),
+                    "case_kind": case["case_kind"],
+                    "case_name": case["display_name"],
+                    "command_type": case["command_type"],
+                    "workflow_name": case["workflow_name"],
+                    "workflow_path": case["workflow_path"],
+                    "job_name": case["job_name"],
+                    "step_name": case["step_name"],
+                    "line_number": case["line_number"],
+                    "raw_command": case["raw_command"],
+                    "npu_status": status,
+                    "npu_refs": npu_refs,
+                }
+            )
+
+    summary = _summarize_details(details)
+    return {
+        "repo_root": str(repo_root),
+        "generated_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "since_days": since_days,
+        "commit_count": len(commits),
+        "summary": summary,
+        "details": sorted(
+            details,
+            key=lambda row: (
+                row["commit_time"],
+                row["commit_hash"],
+                row["case_kind"],
+                row["workflow_name"],
+                row["case_name"],
+            ),
+        ),
+    }
+
+
+def _collect_commit_cases(repo_root: Path, config: WorkflowConfig, commit: CommitInfo) -> list[dict]:
+    cases: list[dict] = []
+    seen: set[tuple[str, str, str, str, str]] = set()
+    for path_text in commit.changed_files:
+        if _is_workflow_path(path_text):
+            content = _load_git_file(repo_root, commit.commit_hash, path_text)
+            if content is not None:
+                _workflow_info, workflow_cases = parse_workflow_content(
+                    Path(path_text).name,
+                    path_text,
+                    content,
+                    repo_root,
+                    config,
+                )
+                cases.extend(workflow_cases)
+        elif _is_test_python_path(path_text):
+            content = _load_git_file(repo_root, commit.commit_hash, path_text)
+            cases.extend(_build_test_file_cases(commit, path_text, content))
+        elif _is_test_script_path(path_text):
+            cases.append(_build_script_case(commit, path_text))
+
+    deduped: list[dict] = []
+    for case in cases:
+        if case["workflow_kind"] == "npu":
+            continue
+        key = (
+            case["case_kind"],
+            case["command_type"],
+            case["target"],
+            case["workflow_path"],
+            case["raw_command"],
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(case)
+    return deduped
+
+
+def _load_git_file(repo_root: Path, commit_hash: str, path_text: str) -> str | None:
+    try:
+        return _run_git(repo_root, "show", f"{commit_hash}:{path_text}")
+    except subprocess.CalledProcessError:
+        return None
+
+
+def _build_test_file_cases(commit: CommitInfo, path_text: str, content: str | None) -> list[dict]:
+    functions = extract_test_functions_from_text(content) if content is not None else []
+    case_names = [f"{path_text}::{name}" for name in functions] if functions else [path_text]
+    cases: list[dict] = []
+    for case_name in case_names:
+        cases.append(
+            {
+                "workflow_name": commit.commit_hash[:12],
+                "workflow_path": path_text,
+                "file_name": Path(path_text).name,
+                "workflow_kind": "cpu",
+                "pair_key": path_text,
+                "job_name": "commit",
+                "step_name": path_text,
+                "line_number": 1,
+                "command_type": "pytest",
+                "case_kind": UT_KIND,
+                "target": case_name,
+                "raw_command": f"git show {commit.commit_hash}:{path_text}",
+                "signature": "commit-file-change",
+                "case_id": f"{commit.commit_hash}|{path_text}|{case_name}",
+                "display_name": case_name,
+            }
+        )
+    return cases
+
+
+def _build_script_case(commit: CommitInfo, path_text: str) -> dict:
+    return {
+        "workflow_name": commit.commit_hash[:12],
+        "workflow_path": path_text,
+        "file_name": Path(path_text).name,
+        "workflow_kind": "cpu",
+        "pair_key": path_text,
+        "job_name": "commit",
+        "step_name": path_text,
+        "line_number": 1,
+        "command_type": "bash",
+        "case_kind": ST_KIND,
+        "target": path_text,
+        "raw_command": f"git show {commit.commit_hash}:{path_text}",
+        "signature": "commit-file-change",
+        "case_id": f"{commit.commit_hash}|{path_text}",
+        "display_name": path_text,
+    }
+
+
+def _build_head_status_index(head_cases: list[dict]) -> dict[str, dict[str, tuple[str, list[dict]]]]:
+    index = {
+        UT_KIND: {},
+        ST_KIND: {},
+    }
+    for case_kind, details in (
+        (UT_KIND, compare_cases_by_pair(head_cases, UT_KIND)),
+        (ST_KIND, compare_cases_by_pair(head_cases, ST_KIND)),
+    ):
+        for section_key, status in REPORT_STATUSES.items():
+            for item in details[section_key]:
+                current = index[case_kind].get(item["name"])
+                if current and _status_rank(current[0]) <= _status_rank(status):
+                    continue
+                index[case_kind][item["name"]] = (status, item["npu_refs"])
+    return index
+
+
+def _lookup_npu_support(
+    case: dict, status_index: dict[str, dict[str, tuple[str, list[dict]]]]
+) -> tuple[str, list[dict]]:
+    return status_index.get(case["case_kind"], {}).get(case["target"], ("missing_in_npu_workflows", []))
+
+
+def _status_rank(status: str) -> int:
+    order = {
+        "aligned": 0,
+        "manual_review_needed": 1,
+        "missing_in_npu_workflows": 2,
+        "npu_only": 3,
+    }
+    return order.get(status, 99)
+
+
+def _summarize_details(details: list[dict]) -> list[dict]:
+    buckets: dict[tuple[str, str, str], dict] = defaultdict(lambda: {"case_count": 0, "commits": set()})
+    for row in details:
+        key = (row["case_kind"], row["workflow_name"], row["npu_status"])
+        buckets[key]["case_count"] += 1
+        buckets[key]["commits"].add(row["commit_hash"])
+    return [
+        {
+            "case_kind": case_kind,
+            "workflow_name": workflow_name,
+            "npu_status": status,
+            "case_count": payload["case_count"],
+            "commit_count": len(payload["commits"]),
+        }
+        for (case_kind, workflow_name, status), payload in sorted(buckets.items())
+    ]

--- a/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/past_commits.py
+++ b/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/past_commits.py
@@ -25,10 +25,10 @@ from pathlib import Path
 
 from .compare import compare_cases_by_pair
 from .config import ST_KIND, UT_KIND, WorkflowConfig
-from .extractors import extract_test_functions_from_text, normalize_path_text
+from .extractors import normalize_path_text
 from .workflows import parse_workflow_content
 
-CI_RELATED_PREFIXES = (".github/workflows/", "tests/", "examples/")
+WORKFLOW_PREFIX = ".github/workflows/"
 REPORT_STATUSES = {
     "matched": "aligned",
     "cpu_gpu_only": "missing_in_npu_workflows",
@@ -57,22 +57,12 @@ def _run_git(repo_root: Path, *args: str) -> str:
 
 def _is_ci_related(path_text: str) -> bool:
     normalized = normalize_path_text(path_text)
-    return normalized.startswith(CI_RELATED_PREFIXES)
+    return normalized.startswith(WORKFLOW_PREFIX)
 
 
 def _is_workflow_path(path_text: str) -> bool:
     normalized = normalize_path_text(path_text)
     return normalized.startswith(".github/workflows/") and normalized.endswith((".yml", ".yaml"))
-
-
-def _is_test_python_path(path_text: str) -> bool:
-    normalized = normalize_path_text(path_text)
-    return normalized.startswith("tests/") and normalized.endswith(".py")
-
-
-def _is_test_script_path(path_text: str) -> bool:
-    normalized = normalize_path_text(path_text)
-    return normalized.startswith(("tests/", "examples/")) and normalized.endswith(".sh")
 
 
 def list_recent_commits(repo_root: Path, since_days: int) -> list[CommitInfo]:
@@ -126,31 +116,39 @@ def build_past_commit_report(repo_root: Path, config: WorkflowConfig, since_days
     commits = list_recent_commits(repo_root, since_days)
     status_index = _build_head_status_index(head_cases)
     details: list[dict] = []
+    seen_details: set[tuple[str, str]] = set()
     for commit in commits:
         cases = _collect_commit_cases(repo_root, config, commit)
         for case in cases:
+            if not _is_effective_case(repo_root, config, case):
+                continue
             status, npu_refs = _lookup_npu_support(case, status_index)
+            if status == "aligned":
+                continue
+            detail_key = (commit.commit_hash, case["case_id"])
+            if detail_key in seen_details:
+                continue
+            seen_details.add(detail_key)
             details.append(
                 {
                     "commit_hash": commit.commit_hash,
                     "commit_time": commit.commit_time,
                     "commit_title": commit.commit_title,
                     "changed_files": tuple(commit.changed_files),
+                    "affected_path": case["source_path"],
+                    "source_type": case["source_type"],
+                    "case_id": case["case_id"],
                     "case_kind": case["case_kind"],
                     "case_name": case["display_name"],
-                    "command_type": case["command_type"],
-                    "workflow_name": case["workflow_name"],
-                    "workflow_path": case["workflow_path"],
-                    "job_name": case["job_name"],
-                    "step_name": case["step_name"],
+                    "workflow_context": f"{case['workflow_name']} / {case['job_name']} / {case['step_name']}",
                     "line_number": case["line_number"],
-                    "raw_command": case["raw_command"],
                     "npu_status": status,
                     "npu_refs": npu_refs,
                 }
             )
 
     summary = _summarize_details(details)
+    _attach_effective_changed_files(details)
     return {
         "repo_root": str(repo_root),
         "generated_at": dt.datetime.now(dt.timezone.utc).isoformat(),
@@ -163,7 +161,7 @@ def build_past_commit_report(repo_root: Path, config: WorkflowConfig, since_days
                 row["commit_time"],
                 row["commit_hash"],
                 row["case_kind"],
-                row["workflow_name"],
+                row["affected_path"],
                 row["case_name"],
             ),
         ),
@@ -172,41 +170,79 @@ def build_past_commit_report(repo_root: Path, config: WorkflowConfig, since_days
 
 def _collect_commit_cases(repo_root: Path, config: WorkflowConfig, commit: CommitInfo) -> list[dict]:
     cases: list[dict] = []
-    seen: set[tuple[str, str, str, str, str]] = set()
     for path_text in commit.changed_files:
         if _is_workflow_path(path_text):
-            content = _load_git_file(repo_root, commit.commit_hash, path_text)
-            if content is not None:
-                _workflow_info, workflow_cases = parse_workflow_content(
-                    Path(path_text).name,
-                    path_text,
-                    content,
-                    repo_root,
-                    config,
-                )
-                cases.extend(workflow_cases)
-        elif _is_test_python_path(path_text):
-            content = _load_git_file(repo_root, commit.commit_hash, path_text)
-            cases.extend(_build_test_file_cases(commit, path_text, content))
-        elif _is_test_script_path(path_text):
-            cases.append(_build_script_case(commit, path_text))
+            cases.extend(_collect_changed_workflow_cases(repo_root, config, commit, path_text))
 
     deduped: list[dict] = []
+    seen: set[str] = set()
     for case in cases:
         if case["workflow_kind"] == "npu":
             continue
-        key = (
-            case["case_kind"],
-            case["command_type"],
-            case["target"],
-            case["workflow_path"],
-            case["raw_command"],
-        )
+        key = case["case_id"]
         if key in seen:
             continue
         seen.add(key)
         deduped.append(case)
     return deduped
+
+
+def _collect_changed_workflow_cases(
+    repo_root: Path,
+    config: WorkflowConfig,
+    commit: CommitInfo,
+    path_text: str,
+) -> list[dict]:
+    after_content = _load_git_file(repo_root, commit.commit_hash, path_text)
+    if after_content is None:
+        return []
+    after_cases = _parse_workflow_cases(repo_root, config, path_text, after_content)
+    before_content = _load_git_file(repo_root, f"{commit.commit_hash}^", path_text)
+    before_cases = _parse_workflow_cases(repo_root, config, path_text, before_content) if before_content else []
+    before_counts: dict[tuple[str, ...], int] = defaultdict(int)
+    for case in before_cases:
+        before_counts[_case_change_key(case)] += 1
+
+    changed_cases: list[dict] = []
+    after_counts: dict[tuple[str, ...], int] = defaultdict(int)
+    for case in after_cases:
+        key = _case_change_key(case)
+        after_counts[key] += 1
+        if after_counts[key] <= before_counts.get(key, 0):
+            continue
+        case["source_path"] = path_text
+        case["source_type"] = "workflow"
+        changed_cases.append(case)
+    return changed_cases
+
+
+def _parse_workflow_cases(
+    repo_root: Path,
+    config: WorkflowConfig,
+    path_text: str,
+    content: str,
+) -> list[dict]:
+    _workflow_info, workflow_cases = parse_workflow_content(
+        Path(path_text).name,
+        path_text,
+        content,
+        repo_root,
+        config,
+    )
+    return workflow_cases
+
+
+def _case_change_key(case: dict) -> tuple[str, ...]:
+    return (
+        case["case_kind"],
+        case["command_type"],
+        case["target"],
+        case["signature"],
+        case["workflow_name"],
+        case["job_name"],
+        case["step_name"],
+        case["raw_command"],
+    )
 
 
 def _load_git_file(repo_root: Path, commit_hash: str, path_text: str) -> str | None:
@@ -216,75 +252,34 @@ def _load_git_file(repo_root: Path, commit_hash: str, path_text: str) -> str | N
         return None
 
 
-def _build_test_file_cases(commit: CommitInfo, path_text: str, content: str | None) -> list[dict]:
-    functions = extract_test_functions_from_text(content) if content is not None else []
-    case_names = [f"{path_text}::{name}" for name in functions] if functions else [path_text]
-    cases: list[dict] = []
-    for case_name in case_names:
-        cases.append(
-            {
-                "workflow_name": commit.commit_hash[:12],
-                "workflow_path": path_text,
-                "file_name": Path(path_text).name,
-                "workflow_kind": "cpu",
-                "pair_key": path_text,
-                "job_name": "commit",
-                "step_name": path_text,
-                "line_number": 1,
-                "command_type": "pytest",
-                "case_kind": UT_KIND,
-                "target": case_name,
-                "raw_command": f"git show {commit.commit_hash}:{path_text}",
-                "signature": "commit-file-change",
-                "case_id": f"{commit.commit_hash}|{path_text}|{case_name}",
-                "display_name": case_name,
-            }
-        )
-    return cases
-
-
-def _build_script_case(commit: CommitInfo, path_text: str) -> dict:
-    return {
-        "workflow_name": commit.commit_hash[:12],
-        "workflow_path": path_text,
-        "file_name": Path(path_text).name,
-        "workflow_kind": "cpu",
-        "pair_key": path_text,
-        "job_name": "commit",
-        "step_name": path_text,
-        "line_number": 1,
-        "command_type": "bash",
-        "case_kind": ST_KIND,
-        "target": path_text,
-        "raw_command": f"git show {commit.commit_hash}:{path_text}",
-        "signature": "commit-file-change",
-        "case_id": f"{commit.commit_hash}|{path_text}",
-        "display_name": path_text,
-    }
-
-
-def _build_head_status_index(head_cases: list[dict]) -> dict[str, dict[str, tuple[str, list[dict]]]]:
-    index = {
+def _build_head_status_index(head_cases: list[dict]) -> dict[str, dict[str, dict[str, tuple[str, list[dict]]]]]:
+    index: dict[str, dict[str, dict[str, tuple[str, list[dict]]]]] = {
         UT_KIND: {},
         ST_KIND: {},
     }
-    for case_kind, details in (
-        (UT_KIND, compare_cases_by_pair(head_cases, UT_KIND)),
-        (ST_KIND, compare_cases_by_pair(head_cases, ST_KIND)),
-    ):
-        for section_key, status in REPORT_STATUSES.items():
-            for item in details[section_key]:
-                current = index[case_kind].get(item["name"])
-                if current and _status_rank(current[0]) <= _status_rank(status):
-                    continue
-                index[case_kind][item["name"]] = (status, item["npu_refs"])
+    cases_by_pair: dict[str, list[dict]] = defaultdict(list)
+    for case in head_cases:
+        cases_by_pair[case["pair_key"]].append(case)
+
+    for pair_key, pair_cases in cases_by_pair.items():
+        for case_kind in (UT_KIND, ST_KIND):
+            details = compare_cases_by_pair(pair_cases, case_kind)
+            pair_index = index[case_kind].setdefault(pair_key, {})
+            for section_key, status in REPORT_STATUSES.items():
+                for item in details[section_key]:
+                    current = pair_index.get(item["name"])
+                    if current and _status_rank(current[0]) <= _status_rank(status):
+                        continue
+                    pair_index[item["name"]] = (status, item["npu_refs"])
     return index
 
 
 def _lookup_npu_support(
-    case: dict, status_index: dict[str, dict[str, tuple[str, list[dict]]]]
+    case: dict, status_index: dict[str, dict[str, dict[str, tuple[str, list[dict]]]]]
 ) -> tuple[str, list[dict]]:
-    return status_index.get(case["case_kind"], {}).get(case["target"], ("missing_in_npu_workflows", []))
+    pair_key = case.get("pair_key", "")
+    case_bucket = status_index.get(case["case_kind"], {}).get(pair_key, {})
+    return case_bucket.get(case["target"], ("missing_in_npu_workflows", []))
 
 
 def _status_rank(status: str) -> int:
@@ -298,18 +293,65 @@ def _status_rank(status: str) -> int:
 
 
 def _summarize_details(details: list[dict]) -> list[dict]:
-    buckets: dict[tuple[str, str, str], dict] = defaultdict(lambda: {"case_count": 0, "commits": set()})
+    buckets: dict[tuple[str, str], dict] = defaultdict(lambda: {"ut_case_ids": set(), "st_case_ids": set()})
     for row in details:
-        key = (row["case_kind"], row["workflow_name"], row["npu_status"])
-        buckets[key]["case_count"] += 1
-        buckets[key]["commits"].add(row["commit_hash"])
+        if row["npu_status"] == "aligned":
+            continue
+        key = (row["affected_path"], row["npu_status"])
+        if row["case_kind"] == UT_KIND:
+            buckets[key]["ut_case_ids"].add(row["case_id"])
+        else:
+            buckets[key]["st_case_ids"].add(row["case_id"])
     return [
         {
-            "case_kind": case_kind,
-            "workflow_name": workflow_name,
+            "affected_path": affected_path,
             "npu_status": status,
-            "case_count": payload["case_count"],
-            "commit_count": len(payload["commits"]),
+            "ut_gap_count": len(payload["ut_case_ids"]),
+            "st_gap_count": len(payload["st_case_ids"]),
         }
-        for (case_kind, workflow_name, status), payload in sorted(buckets.items())
+        for (affected_path, status), payload in sorted(buckets.items())
     ]
+
+
+def _attach_effective_changed_files(details: list[dict]) -> None:
+    grouped: dict[str, list[dict]] = defaultdict(list)
+    for row in details:
+        grouped[row["commit_hash"]].append(row)
+    for commit_rows in grouped.values():
+        seen_paths: set[str] = set()
+        effective_paths: list[str] = []
+        for row in commit_rows:
+            path = row["affected_path"]
+            if path in seen_paths:
+                continue
+            seen_paths.add(path)
+            effective_paths.append(path)
+        for row in commit_rows:
+            row["effective_changed_files"] = tuple(effective_paths)
+
+
+def _is_effective_case(repo_root: Path, config: WorkflowConfig, case: dict) -> bool:
+    source_path = case.get("source_path", "")
+    source_type = case.get("source_type", "")
+    if source_type == "workflow":
+        content = _load_repo_file(repo_root, source_path)
+        if content is None:
+            return False
+        workflow_info, workflow_cases = parse_workflow_content(
+            Path(source_path).name, source_path, content, repo_root, config
+        )
+        if workflow_info is None:
+            return False
+        current_case_keys = {_case_change_key(current_case) for current_case in workflow_cases}
+        return _case_change_key(case) in current_case_keys
+    return False
+
+
+def _load_repo_file(repo_root: Path, path_text: str) -> str | None:
+    path = repo_root / path_text
+    if not path.is_file():
+        return None
+    try:
+        return path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        return path.read_text(encoding="utf-8", errors="ignore")

--- a/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/past_commits.py
+++ b/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/past_commits.py
@@ -53,6 +53,8 @@ def _run_git(repo_root: Path, *args: str) -> str:
         check=True,
         capture_output=True,
         text=True,
+        encoding="utf-8",
+        errors="ignore",
     )
     return result.stdout
 
@@ -329,14 +331,20 @@ def _case_target_changed(case: dict, changed_files: set[str]) -> bool:
     if case["workflow_path"] in changed_files:
         return True
     if case["command_type"] == "pytest":
-        if case_path in {"tests", "tests/"}:
-            return any(path.startswith("tests/") for path in changed_files)
-        return case_path in changed_files
+        return _path_or_child_changed(case_path, changed_files)
     if case["command_type"] == "bash":
         return case_path in changed_files
     if case["command_type"] == "torchrun":
-        return case_path in changed_files or any(path.startswith(case_path.rstrip("/") + "/") for path in changed_files)
+        return _path_or_child_changed(case_path, changed_files)
     return False
+
+
+def _path_or_child_changed(path_text: str, changed_files: set[str] | tuple[str, ...]) -> bool:
+    normalized = normalize_path_text(path_text).rstrip("/")
+    if normalized in changed_files:
+        return True
+    prefix = normalized + "/"
+    return any(path.startswith(prefix) for path in changed_files)
 
 
 def _case_change_key(case: dict) -> tuple[str, ...]:
@@ -386,11 +394,9 @@ def _commit_touches_case_path(commit: CommitInfo, case: dict) -> bool:
     if case["command_type"] == "bash":
         return case_path in commit.changed_files
     if case["command_type"] == "torchrun":
-        return any(path.startswith(case_path.rstrip("/")) for path in commit.changed_files)
+        return _path_or_child_changed(case_path, commit.changed_files)
     if case["command_type"] == "pytest":
-        if case_path in {"tests", "tests/"}:
-            return any(path.startswith("tests/") for path in commit.changed_files)
-        return case_path in commit.changed_files
+        return _path_or_child_changed(case_path, commit.changed_files)
     return False
 
 

--- a/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/past_commits.py
+++ b/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/past_commits.py
@@ -229,6 +229,7 @@ def build_past_commit_report(repo_root: Path, config: WorkflowConfig, since_days
                 "workflow_context": f"{case['workflow_name']} / {case['job_name']} / {case['step_name']}",
                 "line_number": case["line_number"],
                 "target": case["target"],
+                "signature": case["signature"],
                 "raw_command": case["raw_command"],
                 "npu_status": status,
                 "npu_refs": npu_refs,
@@ -390,8 +391,10 @@ def _commit_touches_case_path(commit: CommitInfo, case: dict) -> bool:
     return False
 
 
-def _build_head_status_index(head_cases: list[dict]) -> dict[str, dict[str, dict[str, tuple[str, list[dict]]]]]:
-    index: dict[str, dict[str, dict[str, tuple[str, list[dict]]]]] = {
+def _build_head_status_index(
+    head_cases: list[dict],
+) -> dict[str, dict[str, dict[tuple[str, str], tuple[str, list[dict]]]]]:
+    index: dict[str, dict[str, dict[tuple[str, str], tuple[str, list[dict]]]]] = {
         UT_KIND: {},
         ST_KIND: {},
     }
@@ -405,19 +408,20 @@ def _build_head_status_index(head_cases: list[dict]) -> dict[str, dict[str, dict
             pair_index = index[case_kind].setdefault(pair_key, {})
             for section_key, status in REPORT_STATUSES.items():
                 for item in details[section_key]:
-                    current = pair_index.get(item["name"])
+                    key = (item["command_type"], item["name"], item["signature"])
+                    current = pair_index.get(key)
                     if current and _status_rank(current[0]) <= _status_rank(status):
                         continue
-                    pair_index[item["name"]] = (status, item["npu_refs"])
+                    pair_index[key] = (status, item["npu_refs"])
     return index
 
 
 def _lookup_npu_support(
-    case: dict, status_index: dict[str, dict[str, dict[str, tuple[str, list[dict]]]]]
+    case: dict, status_index: dict[str, dict[str, dict[tuple[str, str], tuple[str, list[dict]]]]]
 ) -> tuple[str, list[dict]]:
     pair_key = case.get("pair_key", "")
     case_bucket = status_index.get(case["case_kind"], {}).get(pair_key, {})
-    return case_bucket.get(case["target"], ("missing_in_npu_workflows", []))
+    return case_bucket.get((case["command_type"], case["target"], case["signature"]), ("missing_in_npu_workflows", []))
 
 
 def _status_rank(status: str) -> int:

--- a/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/past_commits.py
+++ b/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/past_commits.py
@@ -246,6 +246,7 @@ def build_past_commit_report(repo_root: Path, config: WorkflowConfig, since_days
         )
         workflow_changes.append(workflow_row)
 
+    workflow_changes = sorted(workflow_changes, key=_workflow_change_sort_key)
     summary = _summarize_details(case_details)
     commit_details = _build_commit_details(commits, workflow_changes, case_details)
     return {
@@ -290,6 +291,11 @@ def _workflow_status(base_info: object | None, head_info: object | None) -> str:
     if base_info is not None and head_info is None:
         return "removed"
     return "modified"
+
+
+def _workflow_change_sort_key(row: dict) -> tuple[int, str]:
+    status_order = {"added": 0, "modified": 1, "removed": 2}
+    return status_order.get(row["workflow_status"], 99), row["workflow_path"]
 
 
 def _collect_window_changed_files(commits: list[CommitInfo]) -> set[str]:

--- a/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/past_commits.py
+++ b/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/past_commits.py
@@ -102,7 +102,7 @@ def _get_commit_info(repo_root: Path, commit_hash: str) -> CommitInfo:
 
 
 def _list_changed_files(repo_root: Path, commit_hash: str) -> tuple[str, ...]:
-    output = _run_git(repo_root, "diff-tree", "--no-commit-id", "--name-only", "--no-renames", "-r", commit_hash)
+    output = _run_git(repo_root, "diff-tree", "--no-commit-id", "--name-only", "--no-renames", "-r", "-m", commit_hash)
     return tuple(normalize_path_text(line) for line in output.splitlines() if line.strip() and _is_relevant_path(line))
 
 
@@ -402,8 +402,8 @@ def _commit_touches_case_path(commit: CommitInfo, case: dict) -> bool:
 
 def _build_head_status_index(
     head_cases: list[dict],
-) -> dict[str, dict[str, dict[tuple[str, str], tuple[str, list[dict]]]]]:
-    index: dict[str, dict[str, dict[tuple[str, str], tuple[str, list[dict]]]]] = {
+) -> dict[str, dict[str, dict[tuple[str, str, str], tuple[str, list[dict]]]]]:
+    index: dict[str, dict[str, dict[tuple[str, str, str], tuple[str, list[dict]]]]] = {
         UT_KIND: {},
         ST_KIND: {},
     }
@@ -417,16 +417,24 @@ def _build_head_status_index(
             pair_index = index[case_kind].setdefault(pair_key, {})
             for section_key, status in REPORT_STATUSES.items():
                 for item in details[section_key]:
-                    key = (item["command_type"], item["name"], item["signature"])
-                    current = pair_index.get(key)
-                    if current and _status_rank(current[0]) <= _status_rank(status):
-                        continue
-                    pair_index[key] = (status, item["npu_refs"])
+                    if section_key == "matched":
+                        key = (item["command_type"], item["name"], item["signature"])
+                        current = pair_index.get(key)
+                        if current and _status_rank(current[0]) <= _status_rank(status):
+                            continue
+                        pair_index[key] = (status, item["npu_refs"])
+                    else:
+                        for ref in item["cpu_gpu_refs"]:
+                            key = (item["command_type"], item["name"], ref["signature"])
+                            current = pair_index.get(key)
+                            if current and _status_rank(current[0]) <= _status_rank(status):
+                                continue
+                            pair_index[key] = (status, item["npu_refs"])
     return index
 
 
 def _lookup_npu_support(
-    case: dict, status_index: dict[str, dict[str, dict[tuple[str, str], tuple[str, list[dict]]]]]
+    case: dict, status_index: dict[str, dict[str, dict[tuple[str, str, str], tuple[str, list[dict]]]]]
 ) -> tuple[str, list[dict]]:
     pair_key = case.get("pair_key", "")
     case_bucket = status_index.get(case["case_kind"], {}).get(pair_key, {})

--- a/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/past_commits.py
+++ b/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/past_commits.py
@@ -198,6 +198,9 @@ def build_past_commit_report(repo_root: Path, config: WorkflowConfig, since_days
     for workflow_path in workflow_paths:
         head_info = head_workflow_infos.get(workflow_path)
         base_info = base_workflow_infos.get(workflow_path)
+        workflow_kind = head_info.workflow_kind if head_info else base_info.workflow_kind
+        if workflow_kind == "npu":
+            continue
         head_workflow_cases = head_cases_by_path.get(workflow_path, [])
         base_case_keys = {_case_change_key(case) for case in base_cases_by_path.get(workflow_path, [])}
         changed_cases = _collect_changed_head_cases(head_workflow_cases, base_case_keys, changed_files)

--- a/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/past_commits.py
+++ b/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/past_commits.py
@@ -70,11 +70,6 @@ def _is_relevant_path(path_text: str) -> bool:
     )
 
 
-def _is_workflow_path(path_text: str) -> bool:
-    normalized = normalize_path_text(path_text)
-    return normalized.startswith(WORKFLOW_PREFIX) and normalized.endswith((".yml", ".yaml"))
-
-
 def _get_first_parent_commits(repo_root: Path, since_days: int) -> list[str]:
     cutoff = (dt.datetime.now(dt.timezone.utc) - dt.timedelta(days=since_days)).isoformat()
     output = _run_git(

--- a/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/past_commits.py
+++ b/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/past_commits.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import datetime as dt
 import subprocess
+import tempfile
 from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import Path
@@ -26,9 +27,10 @@ from pathlib import Path
 from .compare import compare_cases_by_pair
 from .config import ST_KIND, UT_KIND, WorkflowConfig
 from .extractors import normalize_path_text
-from .workflows import parse_workflow_content
+from .workflows import build_workflow_groups, collect_scan_data
 
 WORKFLOW_PREFIX = ".github/workflows/"
+RELEVANT_PREFIXES = (".github/workflows/", "tests/")
 REPORT_STATUSES = {
     "matched": "aligned",
     "cpu_gpu_only": "missing_in_npu_workflows",
@@ -55,181 +57,276 @@ def _run_git(repo_root: Path, *args: str) -> str:
     return result.stdout
 
 
-def _is_ci_related(path_text: str) -> bool:
+def _normalize_commit_commit_hash(commit_hash: str) -> str:
+    return commit_hash.strip()
+
+
+def _is_relevant_path(path_text: str) -> bool:
     normalized = normalize_path_text(path_text)
-    return normalized.startswith(WORKFLOW_PREFIX)
+    return normalized.startswith(RELEVANT_PREFIXES) or (
+        normalized.startswith("examples/") and normalized.endswith(".sh")
+    )
 
 
 def _is_workflow_path(path_text: str) -> bool:
     normalized = normalize_path_text(path_text)
-    return normalized.startswith(".github/workflows/") and normalized.endswith((".yml", ".yaml"))
+    return normalized.startswith(WORKFLOW_PREFIX) and normalized.endswith((".yml", ".yaml"))
 
 
-def list_recent_commits(repo_root: Path, since_days: int) -> list[CommitInfo]:
-    """Return commits in HEAD history during the last N days that touch CI-related paths."""
+def _get_first_parent_commits(repo_root: Path, since_days: int) -> list[str]:
     cutoff = (dt.datetime.now(dt.timezone.utc) - dt.timedelta(days=since_days)).isoformat()
     output = _run_git(
         repo_root,
-        "log",
+        "rev-list",
+        "--first-parent",
+        "--reverse",
         "--since",
         cutoff,
-        "--pretty=format:%H%x1f%cI%x1f%s",
-        "--name-only",
-        "--no-renames",
         "HEAD",
     )
-    commits: list[CommitInfo] = []
-    current_hash = ""
-    current_time = ""
-    current_title = ""
-    current_files: list[str] = []
+    return [_normalize_commit_commit_hash(line) for line in output.splitlines() if line.strip()]
 
-    def flush() -> None:
-        if not current_hash:
-            return
-        related_files = tuple(path for path in current_files if _is_ci_related(path))
-        if related_files:
-            commits.append(
-                CommitInfo(
-                    commit_hash=current_hash,
-                    commit_time=current_time,
-                    commit_title=current_title,
-                    changed_files=related_files,
-                )
-            )
 
-    for line in output.splitlines():
-        if not line.strip():
-            continue
-        if "\x1f" in line:
-            flush()
-            current_hash, current_time, current_title = line.split("\x1f", 2)
-            current_files = []
-            continue
-        current_files.append(normalize_path_text(line))
-    flush()
+def _get_commit_info(repo_root: Path, commit_hash: str) -> CommitInfo:
+    payload = _run_git(repo_root, "show", "-s", "--format=%H%x1f%cI%x1f%s", commit_hash).strip()
+    commit_id, commit_time, commit_title = payload.split("\x1f", 2)
+    changed_files = _list_changed_files(repo_root, commit_hash)
+    return CommitInfo(
+        commit_hash=commit_id,
+        commit_time=commit_time,
+        commit_title=commit_title,
+        changed_files=changed_files,
+    )
+
+
+def _list_changed_files(repo_root: Path, commit_hash: str) -> tuple[str, ...]:
+    output = _run_git(repo_root, "diff-tree", "--no-commit-id", "--name-only", "--no-renames", "-r", commit_hash)
+    return tuple(normalize_path_text(line) for line in output.splitlines() if line.strip() and _is_relevant_path(line))
+
+
+def _get_commit_sequence(repo_root: Path, since_days: int) -> list[CommitInfo]:
+    commits = [
+        _get_commit_info(repo_root, commit_hash) for commit_hash in _get_first_parent_commits(repo_root, since_days)
+    ]
     return commits
 
 
-def build_past_commit_report(repo_root: Path, config: WorkflowConfig, since_days: int, head_cases: list[dict]) -> dict:
-    """Build a past-N-days report using the current HEAD scan as the NPU baseline."""
-    commits = list_recent_commits(repo_root, since_days)
-    status_index = _build_head_status_index(head_cases)
-    details: list[dict] = []
-    seen_details: set[tuple[str, str]] = set()
-    for commit in commits:
-        cases = _collect_commit_cases(repo_root, config, commit)
-        for case in cases:
-            if not _is_effective_case(repo_root, config, case):
-                continue
-            status, npu_refs = _lookup_npu_support(case, status_index)
-            if status == "aligned":
-                continue
-            detail_key = (commit.commit_hash, case["case_id"])
-            if detail_key in seen_details:
-                continue
-            seen_details.add(detail_key)
-            details.append(
-                {
-                    "commit_hash": commit.commit_hash,
-                    "commit_time": commit.commit_time,
-                    "commit_title": commit.commit_title,
-                    "changed_files": tuple(commit.changed_files),
-                    "affected_path": case["source_path"],
-                    "source_type": case["source_type"],
-                    "case_id": case["case_id"],
-                    "case_kind": case["case_kind"],
-                    "case_name": case["display_name"],
-                    "workflow_context": f"{case['workflow_name']} / {case['job_name']} / {case['step_name']}",
-                    "line_number": case["line_number"],
-                    "npu_status": status,
-                    "npu_refs": npu_refs,
-                }
-            )
+def _get_base_commit(repo_root: Path, oldest_commit: str) -> str | None:
+    try:
+        return _run_git(repo_root, "rev-parse", f"{oldest_commit}^").strip()
+    except subprocess.CalledProcessError:
+        return None
 
-    summary = _summarize_details(details)
-    _attach_effective_changed_files(details)
+
+def _collect_relevant_tree_paths(repo_root: Path, commit_hash: str) -> list[str]:
+    output = _run_git(
+        repo_root,
+        "ls-tree",
+        "-r",
+        "--name-only",
+        commit_hash,
+        "--",
+        ".github/workflows",
+        "tests",
+        "examples",
+    )
+    return [normalize_path_text(line) for line in output.splitlines() if line.strip() and _is_relevant_path(line)]
+
+
+def _materialize_snapshot(repo_root: Path, commit_hash: str, snapshot_root: Path) -> None:
+    snapshot_root.mkdir(parents=True, exist_ok=True)
+    for rel_path in _collect_relevant_tree_paths(repo_root, commit_hash):
+        try:
+            content = _run_git(repo_root, "show", f"{commit_hash}:{rel_path}")
+        except subprocess.CalledProcessError:
+            continue
+        target = snapshot_root / Path(rel_path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8", errors="ignore")
+
+
+def _load_snapshot_scan(
+    snapshot_root: Path, config: WorkflowConfig
+) -> tuple[dict[str, dict], list[dict], dict[str, list[dict]], dict[str, object]]:
+    workflow_infos, cases, _ignored_paths = collect_scan_data(snapshot_root, config)
+    grouped = build_workflow_groups(workflow_infos)
+    workflow_infos_by_path = {info.workflow_path: info for info in workflow_infos}
+    cases_by_path: dict[str, list[dict]] = defaultdict(list)
+    for case in cases:
+        cases_by_path[case["workflow_path"]].append(case)
+    return grouped, cases, cases_by_path, workflow_infos_by_path
+
+
+def build_past_commit_report(repo_root: Path, config: WorkflowConfig, since_days: int, head_cases: list[dict]) -> dict:
+    """Build a past-N-days report by comparing the base snapshot with the current HEAD snapshot."""
+    commits = _get_commit_sequence(repo_root, since_days)
+    if not commits:
+        return {
+            "repo_root": str(repo_root),
+            "generated_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+            "since_days": since_days,
+            "commit_count": 0,
+            "summary": [],
+            "workflow_changes": [],
+            "case_details": [],
+            "commit_details": [],
+        }
+
+    base_commit = _get_base_commit(repo_root, commits[0].commit_hash)
+    head_commit = _run_git(repo_root, "rev-parse", "HEAD").strip()
+
+    with tempfile.TemporaryDirectory(prefix="ascend-ci-past-") as temp_dir:
+        temp_root = Path(temp_dir)
+        base_root = temp_root / "base"
+        head_root = temp_root / "head"
+        if base_commit:
+            _materialize_snapshot(repo_root, base_commit, base_root)
+        _materialize_snapshot(repo_root, head_commit, head_root)
+
+        _base_workflow_groups, _base_cases, base_cases_by_path, base_workflow_infos = _load_snapshot_scan(
+            base_root, config
+        )
+        _head_workflow_groups, head_cases_snapshot, head_cases_by_path, head_workflow_infos = _load_snapshot_scan(
+            head_root, config
+        )
+
+    status_index = _build_head_status_index(head_cases if head_cases else head_cases_snapshot)
+    changed_files = _collect_window_changed_files(commits)
+    workflow_changes: list[dict] = []
+    case_details: list[dict] = []
+    workflow_paths = sorted(set(head_cases_by_path) | set(base_cases_by_path))
+    for workflow_path in workflow_paths:
+        head_info = head_workflow_infos.get(workflow_path)
+        base_info = base_workflow_infos.get(workflow_path)
+        head_workflow_cases = head_cases_by_path.get(workflow_path, [])
+        base_case_keys = {_case_change_key(case) for case in base_cases_by_path.get(workflow_path, [])}
+        changed_cases = _collect_changed_head_cases(head_workflow_cases, base_case_keys, changed_files)
+        if not _workflow_changed(base_info, head_info, base_case_keys, head_workflow_cases) and not changed_cases:
+            continue
+
+        touched_commits = _commits_touching_workflow(workflow_path, changed_cases, commits)
+        workflow_row = {
+            "workflow_path": workflow_path,
+            "head_workflow_name": head_info.workflow_name if head_info else "",
+            "base_workflow_name": base_info.workflow_name if base_info else "",
+            "workflow_status": _workflow_status(base_info, head_info),
+            "commit_hashes": tuple(touched_commits),
+            "case_count_head": len(head_workflow_cases),
+            "case_count_base": len(base_cases_by_path.get(workflow_path, [])),
+            "ut_gap_count": 0,
+            "st_gap_count": 0,
+        }
+
+        for case in changed_cases:
+            status, npu_refs = _lookup_npu_support(case, status_index)
+            case_detail = {
+                "workflow_path": workflow_path,
+                "workflow_name": head_info.workflow_name if head_info else case["workflow_name"],
+                "case_id": case["case_id"],
+                "case_name": case["display_name"],
+                "case_kind": case["case_kind"],
+                "command_type": case["command_type"],
+                "workflow_context": f"{case['workflow_name']} / {case['job_name']} / {case['step_name']}",
+                "line_number": case["line_number"],
+                "target": case["target"],
+                "raw_command": case["raw_command"],
+                "npu_status": status,
+                "npu_refs": npu_refs,
+                "commit_hashes": tuple(_commits_touching_case(case, commits)),
+            }
+            case_details.append(case_detail)
+            if status != "aligned":
+                if case["case_kind"] == UT_KIND:
+                    workflow_row["ut_gap_count"] += 1
+                else:
+                    workflow_row["st_gap_count"] += 1
+
+        workflow_row["cases"] = sorted(
+            case_details_for_workflow(case_details, workflow_path), key=lambda row: (row["case_kind"], row["case_name"])
+        )
+        workflow_changes.append(workflow_row)
+
+    summary = _summarize_details(case_details)
+    commit_details = _build_commit_details(commits, workflow_changes, case_details)
     return {
         "repo_root": str(repo_root),
         "generated_at": dt.datetime.now(dt.timezone.utc).isoformat(),
         "since_days": since_days,
         "commit_count": len(commits),
         "summary": summary,
-        "details": sorted(
-            details,
-            key=lambda row: (
-                row["commit_time"],
-                row["commit_hash"],
-                row["case_kind"],
-                row["affected_path"],
-                row["case_name"],
-            ),
+        "workflow_changes": workflow_changes,
+        "case_details": sorted(
+            case_details, key=lambda row: (row["workflow_path"], row["case_kind"], row["case_name"])
         ),
+        "commit_details": commit_details,
     }
 
 
-def _collect_commit_cases(repo_root: Path, config: WorkflowConfig, commit: CommitInfo) -> list[dict]:
-    cases: list[dict] = []
-    for path_text in commit.changed_files:
-        if _is_workflow_path(path_text):
-            cases.extend(_collect_changed_workflow_cases(repo_root, config, commit, path_text))
+def case_details_for_workflow(case_details: list[dict], workflow_path: str) -> list[dict]:
+    return [row for row in case_details if row["workflow_path"] == workflow_path]
 
-    deduped: list[dict] = []
-    seen: set[str] = set()
-    for case in cases:
+
+def _workflow_changed(
+    base_info: object | None,
+    head_info: object | None,
+    base_case_keys: set[tuple[str, ...]],
+    head_cases: list[dict],
+) -> bool:
+    if base_info is None or head_info is None:
+        return True
+    if (
+        base_info.workflow_name != head_info.workflow_name
+        or base_info.workflow_kind != head_info.workflow_kind
+        or base_info.pair_key != head_info.pair_key
+    ):
+        return True
+    head_case_keys = {_case_change_key(case) for case in head_cases}
+    return head_case_keys != base_case_keys
+
+
+def _workflow_status(base_info: object | None, head_info: object | None) -> str:
+    if base_info is None and head_info is not None:
+        return "added"
+    if base_info is not None and head_info is None:
+        return "removed"
+    return "modified"
+
+
+def _collect_window_changed_files(commits: list[CommitInfo]) -> set[str]:
+    return {path for commit in commits for path in commit.changed_files}
+
+
+def _collect_changed_head_cases(
+    head_cases: list[dict],
+    base_case_keys: set[tuple[str, ...]],
+    changed_files: set[str],
+) -> list[dict]:
+    changed_cases: list[dict] = []
+    seen_case_ids: set[str] = set()
+    for case in head_cases:
         if case["workflow_kind"] == "npu":
             continue
-        key = case["case_id"]
-        if key in seen:
-            continue
-        seen.add(key)
-        deduped.append(case)
-    return deduped
-
-
-def _collect_changed_workflow_cases(
-    repo_root: Path,
-    config: WorkflowConfig,
-    commit: CommitInfo,
-    path_text: str,
-) -> list[dict]:
-    after_content = _load_git_file(repo_root, commit.commit_hash, path_text)
-    if after_content is None:
-        return []
-    after_cases = _parse_workflow_cases(repo_root, config, path_text, after_content)
-    before_content = _load_git_file(repo_root, f"{commit.commit_hash}^", path_text)
-    before_cases = _parse_workflow_cases(repo_root, config, path_text, before_content) if before_content else []
-    before_counts: dict[tuple[str, ...], int] = defaultdict(int)
-    for case in before_cases:
-        before_counts[_case_change_key(case)] += 1
-
-    changed_cases: list[dict] = []
-    after_counts: dict[tuple[str, ...], int] = defaultdict(int)
-    for case in after_cases:
-        key = _case_change_key(case)
-        after_counts[key] += 1
-        if after_counts[key] <= before_counts.get(key, 0):
-            continue
-        case["source_path"] = path_text
-        case["source_type"] = "workflow"
-        changed_cases.append(case)
+        if _case_change_key(case) not in base_case_keys or _case_target_changed(case, changed_files):
+            if case["case_id"] in seen_case_ids:
+                continue
+            seen_case_ids.add(case["case_id"])
+            changed_cases.append(case)
     return changed_cases
 
 
-def _parse_workflow_cases(
-    repo_root: Path,
-    config: WorkflowConfig,
-    path_text: str,
-    content: str,
-) -> list[dict]:
-    _workflow_info, workflow_cases = parse_workflow_content(
-        Path(path_text).name,
-        path_text,
-        content,
-        repo_root,
-        config,
-    )
-    return workflow_cases
+def _case_target_changed(case: dict, changed_files: set[str]) -> bool:
+    case_path = normalize_path_text(case["target"].split("::", 1)[0])
+    if case["workflow_path"] in changed_files:
+        return True
+    if case["command_type"] == "pytest":
+        if case_path in {"tests", "tests/"}:
+            return any(path.startswith("tests/") for path in changed_files)
+        return case_path in changed_files
+    if case["command_type"] == "bash":
+        return case_path in changed_files
+    if case["command_type"] == "torchrun":
+        return case_path in changed_files or any(path.startswith(case_path.rstrip("/") + "/") for path in changed_files)
+    return False
 
 
 def _case_change_key(case: dict) -> tuple[str, ...]:
@@ -245,11 +342,46 @@ def _case_change_key(case: dict) -> tuple[str, ...]:
     )
 
 
-def _load_git_file(repo_root: Path, commit_hash: str, path_text: str) -> str | None:
-    try:
-        return _run_git(repo_root, "show", f"{commit_hash}:{path_text}")
-    except subprocess.CalledProcessError:
-        return None
+def _commits_touching_workflow(workflow_path: str, added_cases: list[dict], commits: list[CommitInfo]) -> list[str]:
+    touched: list[str] = []
+    seen: set[str] = set()
+    for commit in commits:
+        if workflow_path in commit.changed_files:
+            if commit.commit_hash not in seen:
+                seen.add(commit.commit_hash)
+                touched.append(commit.commit_hash)
+            continue
+        if any(_commit_touches_case_path(commit, case) for case in added_cases):
+            if commit.commit_hash not in seen:
+                seen.add(commit.commit_hash)
+                touched.append(commit.commit_hash)
+    return touched
+
+
+def _commits_touching_case(case: dict, commits: list[CommitInfo]) -> list[str]:
+    touched: list[str] = []
+    seen: set[str] = set()
+    for commit in commits:
+        if _commit_touches_case_path(commit, case):
+            if commit.commit_hash not in seen:
+                seen.add(commit.commit_hash)
+                touched.append(commit.commit_hash)
+    return touched
+
+
+def _commit_touches_case_path(commit: CommitInfo, case: dict) -> bool:
+    case_path = normalize_path_text(case["target"].split("::", 1)[0])
+    if case["workflow_path"] in commit.changed_files:
+        return True
+    if case["command_type"] == "bash":
+        return case_path in commit.changed_files
+    if case["command_type"] == "torchrun":
+        return any(path.startswith(case_path.rstrip("/")) for path in commit.changed_files)
+    if case["command_type"] == "pytest":
+        if case_path in {"tests", "tests/"}:
+            return any(path.startswith("tests/") for path in commit.changed_files)
+        return case_path in commit.changed_files
+    return False
 
 
 def _build_head_status_index(head_cases: list[dict]) -> dict[str, dict[str, dict[str, tuple[str, list[dict]]]]]:
@@ -297,7 +429,7 @@ def _summarize_details(details: list[dict]) -> list[dict]:
     for row in details:
         if row["npu_status"] == "aligned":
             continue
-        key = (row["affected_path"], row["npu_status"])
+        key = (row["workflow_path"], row["npu_status"])
         if row["case_kind"] == UT_KIND:
             buckets[key]["ut_case_ids"].add(row["case_id"])
         else:
@@ -313,45 +445,32 @@ def _summarize_details(details: list[dict]) -> list[dict]:
     ]
 
 
-def _attach_effective_changed_files(details: list[dict]) -> None:
-    grouped: dict[str, list[dict]] = defaultdict(list)
-    for row in details:
-        grouped[row["commit_hash"]].append(row)
-    for commit_rows in grouped.values():
-        seen_paths: set[str] = set()
-        effective_paths: list[str] = []
-        for row in commit_rows:
-            path = row["affected_path"]
-            if path in seen_paths:
-                continue
-            seen_paths.add(path)
-            effective_paths.append(path)
-        for row in commit_rows:
-            row["effective_changed_files"] = tuple(effective_paths)
+def _build_commit_details(
+    commits: list[CommitInfo], workflow_changes: list[dict], case_details: list[dict]
+) -> list[dict]:
+    workflow_map: dict[str, list[str]] = defaultdict(list)
+    for change in workflow_changes:
+        for commit_hash in change["commit_hashes"]:
+            workflow_map[commit_hash].append(change["workflow_path"])
+    case_map: dict[str, list[str]] = defaultdict(list)
+    for detail in case_details:
+        for commit_hash in detail["commit_hashes"]:
+            case_map[commit_hash].append(detail["workflow_path"])
 
-
-def _is_effective_case(repo_root: Path, config: WorkflowConfig, case: dict) -> bool:
-    source_path = case.get("source_path", "")
-    source_type = case.get("source_type", "")
-    if source_type == "workflow":
-        content = _load_repo_file(repo_root, source_path)
-        if content is None:
-            return False
-        workflow_info, workflow_cases = parse_workflow_content(
-            Path(source_path).name, source_path, content, repo_root, config
+    rows: list[dict] = []
+    for commit in commits:
+        affected_workflows = sorted(
+            set(workflow_map.get(commit.commit_hash, []) + case_map.get(commit.commit_hash, []))
         )
-        if workflow_info is None:
-            return False
-        current_case_keys = {_case_change_key(current_case) for current_case in workflow_cases}
-        return _case_change_key(case) in current_case_keys
-    return False
-
-
-def _load_repo_file(repo_root: Path, path_text: str) -> str | None:
-    path = repo_root / path_text
-    if not path.is_file():
-        return None
-    try:
-        return path.read_text(encoding="utf-8")
-    except UnicodeDecodeError:
-        return path.read_text(encoding="utf-8", errors="ignore")
+        if not affected_workflows:
+            continue
+        rows.append(
+            {
+                "commit_hash": commit.commit_hash,
+                "commit_time": commit.commit_time,
+                "commit_title": commit.commit_title,
+                "changed_files": commit.changed_files,
+                "affected_workflows": tuple(affected_workflows),
+            }
+        )
+    return rows

--- a/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/render.py
+++ b/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/render.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2025 Bytedance Ltd. and/or its affiliates
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/render.py
+++ b/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/render.py
@@ -17,7 +17,13 @@
 
 from __future__ import annotations
 
+from collections import defaultdict
 from itertools import zip_longest
+
+
+def markdown_multiline(value: str) -> str:
+    """Render internal multiline markers without relying on embedded HTML."""
+    return value.replace("<br>", "; ")
 
 
 def render_reference_details(indent: str, label: str, ref: dict | None) -> list[str]:
@@ -105,7 +111,7 @@ def render_report(report: dict) -> str:
     )
     scanned_rows = [
         [
-            row["workflow_name"],
+            markdown_multiline(row["workflow_name"]),
             str(row["cpu_gpu_case_count"]),
             str(row["npu_supported_case_count"]),
         ]
@@ -145,11 +151,20 @@ def render_past_commit_report(report: dict) -> str:
         "",
     ]
     summary_rows = [
-        [row["case_kind"], row["workflow_name"], row["npu_status"], str(row["case_count"]), str(row["commit_count"])]
+        [
+            row["affected_path"],
+            str(row["ut_gap_count"]),
+            str(row["st_gap_count"]),
+        ]
         for row in report["summary"]
     ]
     if summary_rows:
-        lines.extend(render_table(["Case Kind", "Workflow", "NPU Status", "Case Count", "Commit Count"], summary_rows))
+        lines.extend(
+            render_table(
+                ["CPU/GPU and NPU Not Fully Aligned Cases", "UT Gap Count", "ST Gap Count"],
+                summary_rows,
+            )
+        )
     else:
         lines.append("No CI-related commits were found in the selected window.")
     lines.extend(["", "## Commit Details", ""])
@@ -157,21 +172,41 @@ def render_past_commit_report(report: dict) -> str:
     if not details:
         lines.append("- None")
     else:
-        for row in details:
-            lines.append(f"- Commit `{row['commit_hash']}` - {row['commit_title']}")
-            lines.append(f"  - Time: `{row['commit_time']}`")
-            lines.append(f"  - Changed files: `{'<br>'.join(row['changed_files'])}`")
-            lines.append(f"  - Case: `{row['case_name']}`")
-            lines.append(f"  - Kind: `{row['case_kind']}`")
-            lines.append(f"  - Workflow: `{row['workflow_name']} / {row['job_name']} / {row['step_name']}`")
-            lines.append(f"  - Status: `{row['npu_status']}`")
-            if row["npu_refs"]:
-                lines.append("  - NPU refs:")
-                for ref in row["npu_refs"]:
-                    lines.append(
-                        f"    - `{ref['workflow_name']} / {ref['job_name']} / {ref['step_name']}` "
-                        f"`{ref['workflow_path']}` line `{ref['line_number']}`"
-                    )
-            else:
-                lines.append("  - NPU refs: None")
+        for commit_hash, commit_rows in _group_rows_by_commit(details).items():
+            first = commit_rows[0]
+            lines.append(f"- Commit `{first['commit_hash']}` - {first['commit_title']}")
+            lines.append(f"  - Time: `{first['commit_time']}`")
+            lines.append("  - Effective changed files:")
+            for changed_file in first["effective_changed_files"]:
+                lines.append(f"    - `{changed_file}`")
+            lines.append("  - Cases:")
+            for row in commit_rows:
+                lines.append(f"    - Case: `{row['case_name']}`")
+                lines.append(f"      - Kind: `{row['case_kind']}`")
+                lines.append(f"      - Affected path: `{row['affected_path']}`")
+                lines.append(f"      - Line number: `{row['line_number']}`")
+                lines.append(f"      - Workflow context: `{row['workflow_context']}`")
+                lines.append(f"      - Source type: `{row['source_type']}`")
+                lines.append(f"      - Status: `{row['npu_status']}`")
+                if row["npu_refs"]:
+                    lines.append("      - NPU refs:")
+                    for ref in row["npu_refs"]:
+                        lines.append(
+                            f"        - `{ref['workflow_name']} / {ref['job_name']} / {ref['step_name']}` "
+                            f"`{ref['workflow_path']}` line `{ref['line_number']}`"
+                        )
+                else:
+                    lines.append("      - NPU refs: None")
     return "\n".join(lines).rstrip() + "\n"
+
+
+def _group_rows_by_commit(details: list[dict]) -> dict[str, list[dict]]:
+    grouped: dict[str, list[dict]] = defaultdict(list)
+    for row in details:
+        grouped[row["commit_hash"]].append(row)
+    return dict(
+        sorted(
+            grouped.items(),
+            key=lambda item: (item[1][0]["commit_time"], item[0]),
+        )
+    )

--- a/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/render.py
+++ b/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/render.py
@@ -130,3 +130,48 @@ def render_report(report: dict) -> str:
         ):
             lines.extend(render_case_section(section_title, report[key][section_key]))
     return "\n".join(lines).rstrip() + "\n"
+
+
+def render_past_commit_report(report: dict) -> str:
+    """Render the past-N-days commit analysis as Markdown."""
+    lines = [
+        "# Ascend CI Past N Days Commit Analysis",
+        "",
+        f"Repository: `{report['repo_root']}`",
+        f"Window: past `{report['since_days']}` days",
+        f"Commits scanned: `{report['commit_count']}`",
+        "",
+        "## Summary",
+        "",
+    ]
+    summary_rows = [
+        [row["case_kind"], row["workflow_name"], row["npu_status"], str(row["case_count"]), str(row["commit_count"])]
+        for row in report["summary"]
+    ]
+    if summary_rows:
+        lines.extend(render_table(["Case Kind", "Workflow", "NPU Status", "Case Count", "Commit Count"], summary_rows))
+    else:
+        lines.append("No CI-related commits were found in the selected window.")
+    lines.extend(["", "## Commit Details", ""])
+    details = report["details"]
+    if not details:
+        lines.append("- None")
+    else:
+        for row in details:
+            lines.append(f"- Commit `{row['commit_hash']}` - {row['commit_title']}")
+            lines.append(f"  - Time: `{row['commit_time']}`")
+            lines.append(f"  - Changed files: `{'<br>'.join(row['changed_files'])}`")
+            lines.append(f"  - Case: `{row['case_name']}`")
+            lines.append(f"  - Kind: `{row['case_kind']}`")
+            lines.append(f"  - Workflow: `{row['workflow_name']} / {row['job_name']} / {row['step_name']}`")
+            lines.append(f"  - Status: `{row['npu_status']}`")
+            if row["npu_refs"]:
+                lines.append("  - NPU refs:")
+                for ref in row["npu_refs"]:
+                    lines.append(
+                        f"    - `{ref['workflow_name']} / {ref['job_name']} / {ref['step_name']}` "
+                        f"`{ref['workflow_path']}` line `{ref['line_number']}`"
+                    )
+            else:
+                lines.append("  - NPU refs: None")
+    return "\n".join(lines).rstrip() + "\n"

--- a/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/render.py
+++ b/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/render.py
@@ -186,8 +186,8 @@ def render_past_commit_report(report: dict) -> str:
                 [
                     "Workflow",
                     "Change",
-                    "Base Case Count",
-                    "HEAD Case Count",
+                    "Window Start Case Count",
+                    "Current HEAD Case Count",
                     "UT Gap Count",
                     "ST Gap Count",
                     "Related Commits",

--- a/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/render.py
+++ b/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/render.py
@@ -17,7 +17,6 @@
 
 from __future__ import annotations
 
-from collections import defaultdict
 from itertools import zip_longest
 
 
@@ -166,47 +165,75 @@ def render_past_commit_report(report: dict) -> str:
             )
         )
     else:
-        lines.append("No CI-related commits were found in the selected window.")
-    lines.extend(["", "## Commit Details", ""])
-    details = report["details"]
-    if not details:
+        lines.append("No changed CPU/GPU workflow cases are missing or divergent on NPU in the selected window.")
+
+    lines.extend(["", "## Changed Workflows", ""])
+    workflow_rows = [
+        [
+            row["workflow_path"],
+            row["workflow_status"],
+            str(row["case_count_base"]),
+            str(row["case_count_head"]),
+            str(row["ut_gap_count"]),
+            str(row["st_gap_count"]),
+            ", ".join(commit[:12] for commit in row["commit_hashes"]),
+        ]
+        for row in report["workflow_changes"]
+    ]
+    if workflow_rows:
+        lines.extend(
+            render_table(
+                [
+                    "Workflow",
+                    "Change",
+                    "Base Case Count",
+                    "HEAD Case Count",
+                    "UT Gap Count",
+                    "ST Gap Count",
+                    "Related Commits",
+                ],
+                workflow_rows,
+            )
+        )
+    else:
+        lines.append("No effective workflow or workflow-referenced UT/ST changes were found in the selected window.")
+
+    lines.extend(["", "## Changed Case Details", ""])
+    case_details = report["case_details"]
+    if not case_details:
         lines.append("- None")
     else:
-        for commit_hash, commit_rows in _group_rows_by_commit(details).items():
-            first = commit_rows[0]
-            lines.append(f"- Commit `{first['commit_hash']}` - {first['commit_title']}")
-            lines.append(f"  - Time: `{first['commit_time']}`")
-            lines.append("  - Effective changed files:")
-            for changed_file in first["effective_changed_files"]:
+        for row in case_details:
+            lines.append(f"- Case: `{row['case_name']}`")
+            lines.append(f"  - Kind: `{row['case_kind']}`")
+            lines.append(f"  - Workflow: `{row['workflow_path']}`")
+            lines.append(f"  - Line number: `{row['line_number']}`")
+            lines.append(f"  - Workflow context: `{row['workflow_context']}`")
+            lines.append(f"  - Command: `{row['raw_command']}`")
+            lines.append(f"  - NPU support: `{row['npu_status']}`")
+            lines.append(f"  - Related commits: `{', '.join(commit[:12] for commit in row['commit_hashes'])}`")
+            if row["npu_refs"]:
+                lines.append("  - NPU refs:")
+                for ref in row["npu_refs"]:
+                    lines.append(
+                        f"    - `{ref['workflow_name']} / {ref['job_name']} / {ref['step_name']}` "
+                        f"`{ref['workflow_path']}` line `{ref['line_number']}`"
+                    )
+            else:
+                lines.append("  - NPU refs: None")
+
+    lines.extend(["", "## Commit Details", ""])
+    commit_details = report["commit_details"]
+    if not commit_details:
+        lines.append("- None")
+    else:
+        for row in commit_details:
+            lines.append(f"- Commit `{row['commit_hash']}` - {row['commit_title']}")
+            lines.append(f"  - Time: `{row['commit_time']}`")
+            lines.append("  - Changed files:")
+            for changed_file in row["changed_files"]:
                 lines.append(f"    - `{changed_file}`")
-            lines.append("  - Cases:")
-            for row in commit_rows:
-                lines.append(f"    - Case: `{row['case_name']}`")
-                lines.append(f"      - Kind: `{row['case_kind']}`")
-                lines.append(f"      - Affected path: `{row['affected_path']}`")
-                lines.append(f"      - Line number: `{row['line_number']}`")
-                lines.append(f"      - Workflow context: `{row['workflow_context']}`")
-                lines.append(f"      - Source type: `{row['source_type']}`")
-                lines.append(f"      - Status: `{row['npu_status']}`")
-                if row["npu_refs"]:
-                    lines.append("      - NPU refs:")
-                    for ref in row["npu_refs"]:
-                        lines.append(
-                            f"        - `{ref['workflow_name']} / {ref['job_name']} / {ref['step_name']}` "
-                            f"`{ref['workflow_path']}` line `{ref['line_number']}`"
-                        )
-                else:
-                    lines.append("      - NPU refs: None")
+            lines.append("  - Effective workflows:")
+            for workflow_path in row["affected_workflows"]:
+                lines.append(f"    - `{workflow_path}`")
     return "\n".join(lines).rstrip() + "\n"
-
-
-def _group_rows_by_commit(details: list[dict]) -> dict[str, list[dict]]:
-    grouped: dict[str, list[dict]] = defaultdict(list)
-    for row in details:
-        grouped[row["commit_hash"]].append(row)
-    return dict(
-        sorted(
-            grouped.items(),
-            key=lambda item: (item[1][0]["commit_time"], item[0]),
-        )
-    )

--- a/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/render.py
+++ b/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/render.py
@@ -20,11 +20,6 @@ from __future__ import annotations
 from itertools import zip_longest
 
 
-def markdown_multiline(value: str) -> str:
-    """Render internal multiline markers without relying on embedded HTML."""
-    return value.replace("<br>", "; ")
-
-
 def render_reference_details(indent: str, label: str, ref: dict | None) -> list[str]:
     """Render one workflow location with enough context for manual navigation."""
     lines = [f"{indent}- {label}:"]
@@ -34,6 +29,7 @@ def render_reference_details(indent: str, label: str, ref: dict | None) -> list[
     lines.append(f"{indent}  - Workflow file: `{ref['workflow_path']}`")
     lines.append(f"{indent}  - Line number: `{ref['line_number']}`")
     lines.append(f"{indent}  - Workflow context: `{ref['workflow_name']} / {ref['job_name']} / {ref['step_name']}`")
+    lines.append(f"{indent}  - Signature: `{ref['signature']}`")
     lines.append(f"{indent}  - Command: `{ref['raw_command']}`")
     return lines
 
@@ -76,6 +72,30 @@ def render_case_section(title: str, items: list[dict]) -> list[str]:
     return lines
 
 
+def markdown_table_multiline(value: str) -> str:
+    """Render internal multiline markers inside Markdown table cells."""
+    return value.replace("<br>", "<br/>")
+
+
+def render_scanned_workflows(rows: list[dict]) -> list[str]:
+    """Render scanned workflow groups as a Markdown table."""
+    if not rows:
+        return ["No workflows were scanned."]
+
+    scanned_rows = [
+        [
+            markdown_table_multiline(row["workflow_name"]),
+            str(row["cpu_gpu_case_count"]),
+            str(row["npu_supported_case_count"]),
+        ]
+        for row in rows
+    ]
+    return render_table(
+        ["Workflow Name", "CPU/GPU Case Count", "NPU Supported Case Count"],
+        scanned_rows,
+    )
+
+
 def render_report(report: dict) -> str:
     """Render the final Markdown report."""
     lines = [
@@ -108,23 +128,7 @@ def render_report(report: dict) -> str:
             "",
         ]
     )
-    scanned_rows = [
-        [
-            markdown_multiline(row["workflow_name"]),
-            str(row["cpu_gpu_case_count"]),
-            str(row["npu_supported_case_count"]),
-        ]
-        for row in report["scanned_workflows"]
-    ]
-    if scanned_rows:
-        lines.extend(
-            render_table(
-                ["Workflow Name", "CPU/GPU Case Count", "NPU Supported Case Count"],
-                scanned_rows,
-            )
-        )
-    else:
-        lines.append("No workflows were scanned.")
+    lines.extend(render_scanned_workflows(report["scanned_workflows"]))
     for title, key in (("UT Case Details", "ut_details"), ("ST Case Details", "st_details")):
         lines.extend([f"## {title}", ""])
         for section_title, section_key in (
@@ -209,6 +213,7 @@ def render_past_commit_report(report: dict) -> str:
             lines.append(f"  - Workflow: `{row['workflow_path']}`")
             lines.append(f"  - Line number: `{row['line_number']}`")
             lines.append(f"  - Workflow context: `{row['workflow_context']}`")
+            lines.append(f"  - Signature: `{row['signature']}`")
             lines.append(f"  - Command: `{row['raw_command']}`")
             lines.append(f"  - NPU support: `{row['npu_status']}`")
             lines.append(f"  - Related commits: `{', '.join(commit[:12] for commit in row['commit_hashes'])}`")

--- a/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/render.py
+++ b/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/render.py
@@ -164,7 +164,11 @@ def render_past_commit_report(report: dict) -> str:
     if summary_rows:
         lines.extend(
             render_table(
-                ["CPU/GPU and NPU Not Fully Aligned Cases", "UT Gap Count", "ST Gap Count"],
+                [
+                    "CPU/GPU and NPU Not Fully Aligned Cases",
+                    "UT Not Fully Aligned with NPU Count",
+                    "ST Not Fully Aligned with NPU Count",
+                ],
                 summary_rows,
             )
         )
@@ -192,8 +196,8 @@ def render_past_commit_report(report: dict) -> str:
                     "Change",
                     "Window Start Case Count",
                     "Current HEAD Case Count",
-                    "UT Gap Count",
-                    "ST Gap Count",
+                    "UT Not Fully Aligned with NPU Count",
+                    "ST Not Fully Aligned with NPU Count",
                     "Related Commits",
                 ],
                 workflow_rows,

--- a/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/workflows.py
+++ b/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/workflows.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2025 Bytedance Ltd. and/or its affiliates
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/workflows.py
+++ b/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/workflows.py
@@ -301,24 +301,29 @@ def _extract_cases_from_command(
     return deduped
 
 
-def parse_workflow(path: Path, repo_root: Path, config: WorkflowConfig) -> tuple[WorkflowInfo | None, list[dict]]:
-    """Parse one workflow file and extract test cases from each run block."""
-    file_name = path.name
+def parse_workflow_content(
+    file_name: str,
+    workflow_path: str,
+    content: str,
+    repo_root: Path,
+    config: WorkflowConfig,
+) -> tuple[WorkflowInfo | None, list[dict]]:
+    """Parse one workflow content string and extract test cases from each run block."""
     if is_ignored_workflow(file_name, config):
         return None, []
 
-    content = load_text(path)
-    workflow_name = path.stem
+    file_stem = Path(file_name).stem
+    workflow_name = file_stem
     name_match = WORKFLOW_NAME_RE.search(content)
     if name_match:
         workflow_name = name_match.group(1).strip().strip("\"'")
-    workflow_kind = classify_workflow(path.stem, content)
+    workflow_kind = classify_workflow(file_stem, content)
     workflow_info = WorkflowInfo(
         workflow_name=workflow_name,
-        workflow_path=normalize_path_text(path.relative_to(repo_root).as_posix()),
+        workflow_path=normalize_path_text(workflow_path),
         file_name=file_name,
         workflow_kind=workflow_kind,
-        pair_key=workflow_pair_key(path.stem),
+        pair_key=workflow_pair_key(file_stem),
     )
 
     lines = content.splitlines()
@@ -356,6 +361,13 @@ def parse_workflow(path: Path, repo_root: Path, config: WorkflowConfig) -> tuple
             continue
         idx += 1
     return workflow_info, cases
+
+
+def parse_workflow(path: Path, repo_root: Path, config: WorkflowConfig) -> tuple[WorkflowInfo | None, list[dict]]:
+    """Parse one workflow file and extract test cases from each run block."""
+    file_name = path.name
+    rel_path = normalize_path_text(path.relative_to(repo_root).as_posix())
+    return parse_workflow_content(file_name, rel_path, load_text(path), repo_root, config)
 
 
 def collect_scan_data(repo_root: Path, config: WorkflowConfig) -> tuple[list[WorkflowInfo], list[dict], list[str]]:

--- a/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/workflows.py
+++ b/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/workflows.py
@@ -38,7 +38,10 @@ RUN_RE = re.compile(r"^(\s*)run:\s*(.*)$")
 RUNS_ON_ASCEND_RE = re.compile(r"runs-on:\s+.*(?:aarch64|a2|a3)", re.IGNORECASE)
 IMAGE_ASCEND_RE = re.compile(r"image:\s+.*ascend", re.IGNORECASE)
 ENV_PREFIX_RE = re.compile(r"^(?:[A-Za-z_][A-Za-z0-9_]*=(?:\"[^\"]*\"|'[^']*'|\S+)\s+)+")
+ENV_ASSIGNMENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=(?:\"[^\"]*\"|'[^']*'|\S+)$")
 TORCHRUN_RE = re.compile(r"\btorchrun\b")
+PYTEST_SELECTION_OPTIONS = {"-k", "-m"}
+PYTEST_IGNORED_OPTIONS = {"--ignore", "--ignore-glob"}
 
 
 def classify_workflow(file_stem: str, content: str) -> str:
@@ -64,18 +67,45 @@ def workflow_pair_key(file_stem: str) -> str:
 
 
 def normalize_signature(command: str, target: str) -> str:
-    """Keep only the command prefixes that materially affect parity matching."""
-    idx = command.find(target) if target else -1
-    env_match = ENV_PREFIX_RE.match(command[:idx] if idx != -1 else command)
-    env_prefix = env_match.group(0).strip() if env_match else ""
-    parts: list[str] = []
-    for key in ("ROLLOUT_NAME", "ENGINE", "STRATEGY", "MODE", "RESUME_MODE", "BACKEND"):
-        match = re.search(rf"{key}=([^\s]+)", env_prefix)
-        if match:
-            parts.append(match.group(0))
-    if "--nproc_per_node" in command or "--nproc-per-node" in command:
-        parts.append("torchrun-distributed")
-    return " ".join(parts).strip()
+    """Normalize the whole test command so parity matching keeps env and args aligned."""
+    tokens = tokenize_command(command)
+    if not tokens:
+        return ""
+
+    if command_uses_pytest(tokens):
+        return _normalize_pytest_signature(tokens)
+
+    return " ".join(normalize_path_text(token) for token in tokens).strip()
+
+
+def _normalize_pytest_signature(tokens: list[str]) -> str:
+    pytest_idx = tokens.index("pytest")
+    prefix_tokens = [token for token in tokens[:pytest_idx] if token not in {"export", "env"}]
+    env_prefix = sorted(normalize_path_text(token) for token in prefix_tokens if ENV_ASSIGNMENT_RE.match(token))
+
+    normalized_tokens: list[str] = []
+    normalized_tokens.extend(env_prefix)
+    normalized_tokens.append("pytest")
+
+    idx = pytest_idx + 1
+    while idx < len(tokens):
+        token = tokens[idx]
+        if token in PYTEST_IGNORED_OPTIONS and idx + 1 < len(tokens):
+            idx += 2
+            continue
+        if token.startswith("--ignore=") or token.startswith("--ignore-glob="):
+            idx += 1
+            continue
+        if token in PYTEST_SELECTION_OPTIONS and idx + 1 < len(tokens):
+            idx += 2
+            continue
+        if token.startswith("-"):
+            normalized_tokens.append(normalize_path_text(token))
+            idx += 1
+            continue
+        idx += 1
+
+    return " ".join(normalized_tokens).strip()
 
 
 def split_shell_commands(command: str) -> list[str]:

--- a/.agent/skills/ascend-ci-case-diff-scan/scripts/scan_ascend_ci_case_diff.py
+++ b/.agent/skills/ascend-ci-case-diff-scan/scripts/scan_ascend_ci_case_diff.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2025 Bytedance Ltd. and/or its affiliates
+# Copyright 2026 Bytedance Ltd. and/or its affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.agent/skills/ascend-ci-case-diff-scan/scripts/scan_ascend_ci_case_diff.py
+++ b/.agent/skills/ascend-ci-case-diff-scan/scripts/scan_ascend_ci_case_diff.py
@@ -23,8 +23,9 @@ from pathlib import Path
 
 from modules.compare import compare_cases_by_pair, summarize_scanned_workflows
 from modules.config import ST_KIND, UT_KIND, load_config, validate_repo_root
-from modules.excel import write_excel_report
-from modules.render import render_report
+from modules.excel import write_excel_report, write_past_commit_excel_report
+from modules.past_commits import build_past_commit_report
+from modules.render import render_past_commit_report, render_report
 from modules.workflows import build_workflow_groups, collect_scan_data
 
 
@@ -41,6 +42,12 @@ def parse_args() -> argparse.Namespace:
         "--output-dir",
         required=True,
         help="Directory where the generated report.md and report.xlsx will be written.",
+    )
+    parser.add_argument(
+        "--since-days",
+        type=int,
+        default=None,
+        help="Optional number of days for past-commit analysis. When set, also write report-past-N.md/xlsx.",
     )
     return parser.parse_args()
 
@@ -70,6 +77,16 @@ def main() -> int:
     write_excel_report(excel_path, report)
     print(report_path)
     print(excel_path)
+    if args.since_days is not None:
+        if args.since_days <= 0:
+            raise ValueError("--since-days must be a positive integer")
+        past_report = build_past_commit_report(repo_root, config, args.since_days, cases)
+        past_report_path = output_dir / f"report-past-{args.since_days}.md"
+        past_report_path.write_text(render_past_commit_report(past_report), encoding="utf-8")
+        past_excel_path = output_dir / f"report-past-{args.since_days}.xlsx"
+        write_past_commit_excel_report(past_excel_path, past_report)
+        print(past_report_path)
+        print(past_excel_path)
     return 0
 
 

--- a/.agent/skills/ascend-ci-case-diff-scan/scripts/scan_ascend_ci_case_diff.py
+++ b/.agent/skills/ascend-ci-case-diff-scan/scripts/scan_ascend_ci_case_diff.py
@@ -47,7 +47,10 @@ def parse_args() -> argparse.Namespace:
         "--since-days",
         type=int,
         default=None,
-        help="Optional number of days for past-commit analysis. When set, also write report-past-N.md/xlsx.",
+        help=(
+            "Optional positive integer for past-N-days analysis. "
+            "When omitted, only report.md/xlsx are written; when set, also write report-past-N.md/xlsx."
+        ),
     )
     return parser.parse_args()
 


### PR DESCRIPTION
## Summary
Enhance `ascend-ci-case-diff-scan` to support past-N-days commit analysis while keeping the full scan unchanged.

## Changes
- Add optional `--since-days N` CLI support
- Keep full scan output as `report.md` and `report.xlsx`
- Generate separate past-N reports as `report-past-N.md` and `report-past-N.xlsx`
- Scope past-N analysis to effective final-state changes within the selected window
- Keep the same workflow-first scan model for full and past-N reports
- Treat NPU workflows as support evidence in past-N reports, not as changed workflow rows
- Tighten case matching to use `command_type + target + signature`
- Improve `pytest` signature handling to reduce false mismatches for function-level UTs
- Update report labels to make NPU alignment gaps clearer
- Refresh skill docs and repo guidance to match the new behavior