### PR TITLE
Fix: workflow parsing bugs, XML char validation, and doc cleanup

### DIFF
--- a/.agent/skills/ascend-ci-case-diff-scan/README.md
+++ b/.agent/skills/ascend-ci-case-diff-scan/README.md
@@ -17,19 +17,28 @@ This skill statically audits a target `verl` repository and reports workflow/cas
 - `gpu_unit_tests.yml` pairs with `npu_unit_tests.yml`
 - Standalone NPU workflows such as `e2e_ascend.yml` and `nightly_ascend.yml` remain NPU-only
 
-## Case rules
+## How cases are classified
 
-- `pytest` means UT
-- UT entries are expanded to concrete test functions or test methods whenever the target Python file can be parsed
-- `torchrun`, `bash tests/*.sh`, and `bash examples/*.sh` mean ST
+- `pytest` commands → **UT** cases, expanded to function-level (`test_*` / `Test*::test_*`) whenever the Python file can be parsed
+- `torchrun`, `bash tests/*.sh`, and `bash examples/*.sh` → **ST** cases, recorded at the command level
 - Repeated commands are kept distinct by `workflow name`, `job name`, and `step name`
-- Use `--repo-root` to point at the target `verl` repository root
-- The scanner reads workflow `run:` commands directly and records only the scripts explicitly invoked by each step
-- `--since-days N` enables a second report for the last `N` merged days and must be a positive integer
-- The past-N-days report keeps the same workflow-first logic as the full scan, but only surfaces CPU/GPU workflows and cases that ended up changed within the window
-- NPU workflows are used as current support evidence in the past report, not as changed-workflow rows
-- For past-N-days cases, `Related Commits` reflects commits in the selected window that touched the workflow or the changed case target
-- `bash` and `torchrun` use strict command-level signatures; `pytest` keeps execution semantics while avoiding false differences from broad discovery selectors
+
+## CLI usage
+
+```bash
+python scripts/scan_ascend_ci_case_diff.py \
+  --repo-root {PATH}/verl \
+  --output-dir ./outputs
+```
+
+- `--repo-root` — path to the target `verl` repository root
+- `--since-days N` — (optional) also generate a past-N-days report; must be a positive integer
+
+## Past-N-days behavior
+
+- Walks first-parent history for merged commits in the last `N` days
+- Reports only effective final-state changes (additions later removed or reverted are excluded)
+- `Related Commits` lists commits that touched the workflow or the changed case target
 
 ## Output
 

--- a/.agent/skills/ascend-ci-case-diff-scan/SKILL.md
+++ b/.agent/skills/ascend-ci-case-diff-scan/SKILL.md
@@ -38,49 +38,21 @@ python .agent/skills/ascend-ci-case-diff-scan/scripts/scan_ascend_ci_case_diff.p
 
 ## Extraction Rules
 
-Recognize only workflow commands that visibly execute tests:
+Recognize only workflow commands that visibly execute tests (see [references/repo-signals.md](./references/repo-signals.md#extractable-command-forms) for details):
 
 - `pytest ... tests/...`
-- `bash tests/.../*.sh`
-- `bash examples/.../*.sh`
+- `bash tests/.../*.sh` or `bash examples/.../*.sh`
 - `torchrun ... tests/...`
 
-For each extracted case, preserve:
+For each extracted case, preserve: `workflow_name`, `job_name`, `step_name`, `command_type`, `target`, `raw_command`, `signature`.
 
-- `workflow_name`
-- `job_name`
-- `step_name`
-- `command_type`
-- `target`
-- `raw_command`
-- `signature`
+When the same command appears in different workflow/job/step contexts, keep cases distinct. For UT, expand to function-level or test-method-level whenever the target file can be parsed. For ST scripts, record only scripts explicitly invoked by the workflow step — do not inspect the script body.
 
-When the same command is repeated, keep cases distinct by `workflow_name`, `job_name`, and `step_name`.
-For UT expansion, treat Python test functions and `Test*::test_*` methods as the reporting unit whenever the target file can be parsed.
-For ST scripts, record only scripts explicitly invoked by the workflow step; do not inspect the script body for nested commands.
-
-Case matching uses `command_type`, `target`, and `signature`.
-
-- `bash` and `torchrun` signatures are strict command-level signatures. Environment assignments and command arguments are part of the test semantics.
-- `pytest` signatures keep execution semantics while avoiding false differences from broad discovery selectors. Function-level UT alignment is decided from the expanded concrete test path plus the retained execution signature.
-- Same target with a materially different retained signature is not treated as aligned.
+Case matching uses `command_type`, `target`, and `signature` (see [references/repo-signals.md](./references/repo-signals.md#matching-expectations) for detailed matching rules).
 
 ## Past-N-Days Analysis
 
-When `--since-days N` is set, the scanner:
-
-- walks the current branch first-parent history for commits merged in the last `N` days
-- compares the window-start snapshot with current `HEAD`
-- keeps only effective final-state changes, so additions that were later removed or reverted are not reported as changed cases
-- starts from CPU/GPU workflows and their referenced UT/ST cases, matching the full-scan workflow-first model
-- uses NPU workflows only as current `HEAD` support evidence, not as rows in `Changed Workflows`
-
-The past report columns should be read as:
-
-- `Window Start Case Count`: extracted cases in that CPU/GPU workflow at the start of the window
-- `Current HEAD Case Count`: extracted cases in that CPU/GPU workflow at current `HEAD`
-- `UT/ST Not Fully Aligned with NPU Count`: changed CPU/GPU UT/ST cases whose current `HEAD` NPU status is not fully aligned, including missing and manual-review cases
-- `Related Commits`: commits in the selected window that touched the workflow or the changed case target
+When `--since-days N` is set, the scanner walks the current branch first-parent history for commits merged in the last `N` days, compares the window-start snapshot with current `HEAD`, and reports only effective final-state changes. See [references/repo-signals.md](./references/repo-signals.md#past-n-days-expectations) for the full scoping and column semantics.
 
 ## Boundaries
 
@@ -92,18 +64,9 @@ The past report columns should be read as:
 
 ## Classification Rules
 
-Use these output categories:
+Output categories: `aligned`, `missing_in_npu_workflows`, `manual_review_needed`, `npu_only`.
 
-- `aligned`
-- `missing_in_npu_workflows`
-- `manual_review_needed`
-- `npu_only`
-
-Treat matching conservatively:
-
-- Exact target matches are the strongest signal.
-- Compatible signatures can be aligned.
-- Different signatures for the same target should fall back to manual review.
+Exact target matches are the strongest signal; different signatures for the same target fall back to `manual_review_needed`. See [references/repo-signals.md](./references/repo-signals.md#matching-expectations) for the full matching rules.
 
 ## Reporting
 

--- a/.agent/skills/ascend-ci-case-diff-scan/SKILL.md
+++ b/.agent/skills/ascend-ci-case-diff-scan/SKILL.md
@@ -17,7 +17,7 @@ The full reports show ignored workflows, paired CPU/GPU and NPU workflows, UT/ST
 
 1. Read [references/repo-signals.md](./references/repo-signals.md) for repo-specific boundaries.
 2. Identify the target `verl` repository root, for example `{PATH}/verl`.
-3. Run the scanner from this repository:
+3. Run the scanner. The commands below assume the working directory is the root of `verl-ascend-recipe` (where `.agent/` lives). You can also `cd` into `scripts/` and run `python scan_ascend_ci_case_diff.py ...` directly.
 
 ```shell
 python .agent/skills/ascend-ci-case-diff-scan/scripts/scan_ascend_ci_case_diff.py \

--- a/.agent/skills/ascend-ci-case-diff-scan/references/repo-signals.md
+++ b/.agent/skills/ascend-ci-case-diff-scan/references/repo-signals.md
@@ -4,25 +4,13 @@ Use these target-repo facts when running `ascend-ci-case-diff-scan` against an e
 
 ## Primary inputs
 
-- `.github/workflows/*.yml`
+- `.github/workflows/*.yml` and `.github/workflows/*.yaml`
 
 ## Workflow scope
 
-Exclude workflows that are not part of meaningful CPU/GPU-vs-NPU test coverage. The default ignored set is maintained in `config/workflow_scope.json`.
+Exclude workflows that are not part of meaningful CPU/GPU-vs-NPU test coverage. The authoritative ignored set is maintained in `config/workflow_scope.json` (supports exact names and `glob` patterns like `docker-*.yml`).
 
-Examples:
-
-- `check-pr-title.yml`
-- `cpu_unit_tests.yml`
-- `doc.yml`
-- `docker-*.yml`
-- `e2e_ppo_trainer.yml`
-- `pre-commit.yml`
-- `precommit-autofix.yml`
-- `sanity.yml`
-- `scorecard.yml`
-- `secrets_scan.yml`
-- `type-coverage-check.yml`
+See that file for the current list.
 
 ## Workflow families
 

--- a/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/excel.py
+++ b/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/excel.py
@@ -411,4 +411,9 @@ def _past_detail_rows(report: dict) -> list[list[object]]:
 
 def _is_valid_xml_char(character: str) -> bool:
     codepoint = ord(character)
-    return codepoint in (0x9, 0xA, 0xD) or 0x20 <= codepoint <= 0xD7FF or 0xE000 <= codepoint <= 0xFFFD
+    return (
+        codepoint in (0x9, 0xA, 0xD)
+        or 0x20 <= codepoint <= 0xD7FF
+        or 0xE000 <= codepoint <= 0xFFFD
+        or 0x10000 <= codepoint <= 0x10FFFF
+    )

--- a/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/extractors.py
+++ b/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/extractors.py
@@ -103,9 +103,13 @@ def extract_bash_target(tokens: list[str]) -> str | None:
     """Extract bash-invoked test scripts from explicit workflow step commands."""
     for idx, token in enumerate(tokens[:-1]):
         if token == "bash":
-            target = normalize_path_text(tokens[idx + 1].strip("\"'"))
-            if target.startswith(("tests/", "examples/")) and target.endswith(".sh"):
-                return target
+            lookahead = idx + 1
+            while lookahead < len(tokens) and tokens[lookahead].startswith("-"):
+                lookahead += 1
+            if lookahead < len(tokens):
+                target = normalize_path_text(tokens[lookahead].strip("\"'"))
+                if target.startswith(("tests/", "examples/")) and target.endswith(".sh"):
+                    return target
     return None
 
 

--- a/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/extractors.py
+++ b/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/extractors.py
@@ -91,7 +91,12 @@ def extract_torchrun_targets(tokens: list[str], torchrun_idx: int) -> list[str]:
         token = tokens[idx]
         if token.startswith("-"):
             if "=" not in token:
-                idx += 1  # skip flag value
+                # Only skip the next token when it looks like a value,
+                # not another flag and not a test target.
+                if idx + 1 < len(tokens):
+                    nxt = tokens[idx + 1]
+                    if not nxt.startswith("-") and not nxt.startswith("tests/"):
+                        idx += 1
             idx += 1
             continue
         normalized = normalize_path_text(token.strip("\"'"))

--- a/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/extractors.py
+++ b/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/extractors.py
@@ -110,11 +110,8 @@ def extract_bash_target(tokens: list[str]) -> str | None:
     """Extract bash-invoked test scripts from explicit workflow step commands."""
     for idx, token in enumerate(tokens[:-1]):
         if token == "bash":
-            lookahead = idx + 1
-            while lookahead < len(tokens) and tokens[lookahead].startswith("-"):
-                lookahead += 1
-            if lookahead < len(tokens):
-                target = normalize_path_text(tokens[lookahead].strip("\"'"))
+            for j in range(idx + 1, len(tokens)):
+                target = normalize_path_text(tokens[j].strip("\"'"))
                 if target.startswith(("tests/", "examples/")) and target.endswith(".sh"):
                     return target
     return None

--- a/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/extractors.py
+++ b/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/extractors.py
@@ -90,6 +90,8 @@ def extract_torchrun_targets(tokens: list[str], torchrun_idx: int) -> list[str]:
     while idx < len(tokens):
         token = tokens[idx]
         if token.startswith("-"):
+            if "=" not in token:
+                idx += 1  # skip flag value
             idx += 1
             continue
         normalized = normalize_path_text(token.strip("\"'"))

--- a/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/workflows.py
+++ b/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/workflows.py
@@ -406,7 +406,7 @@ def collect_scan_data(repo_root: Path, config: WorkflowConfig) -> tuple[list[Wor
     workflow_infos: list[WorkflowInfo] = []
     cases: list[dict] = []
     ignored_paths: list[str] = []
-    for path in sorted(workflow_dir.glob("*.yml")):
+    for path in sorted(set(workflow_dir.glob("*.yml")) | set(workflow_dir.glob("*.yaml"))):
         rel_path = normalize_path_text(path.relative_to(repo_root).as_posix())
         if is_ignored_workflow(path.name, config):
             ignored_paths.append(rel_path)

--- a/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/workflows.py
+++ b/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/workflows.py
@@ -31,7 +31,7 @@ from .extractors import (
     should_keep_target,
 )
 
-WORKFLOW_NAME_RE = re.compile(r"^\s*name:\s*(.+?)\s*$")
+WORKFLOW_NAME_RE = re.compile(r"^\s*name:\s*(.+?)\s*$", re.MULTILINE)
 JOB_RE = re.compile(r"^(\s{2})([A-Za-z0-9_-]+):\s*$")
 STEP_NAME_RE = re.compile(r"^(\s*)-\s+name:\s*(.+?)\s*$")
 RUN_RE = re.compile(r"^(\s*)run:\s*(.*)$")
@@ -98,6 +98,9 @@ def _normalize_pytest_signature(tokens: list[str]) -> str:
             continue
         if token in PYTEST_SELECTION_OPTIONS and idx + 1 < len(tokens):
             idx += 2
+            continue
+        if token.startswith(("-k=", "-m=")):
+            idx += 1
             continue
         if token.startswith("-"):
             normalized_tokens.append(normalize_path_text(token))

--- a/.agent/skills/ascend-ci-case-diff-scan/scripts/scan_ascend_ci_case_diff.py
+++ b/.agent/skills/ascend-ci-case-diff-scan/scripts/scan_ascend_ci_case_diff.py
@@ -58,6 +58,8 @@ def parse_args() -> argparse.Namespace:
 def main() -> int:
     """Run the workflow parity scan."""
     args = parse_args()
+    if args.since_days is not None and args.since_days <= 0:
+        raise ValueError("--since-days must be a positive integer")
     repo_root = Path(args.repo_root).resolve()
     output_dir = Path(args.output_dir).resolve()
     validate_repo_root(repo_root)
@@ -81,8 +83,6 @@ def main() -> int:
     print(report_path)
     print(excel_path)
     if args.since_days is not None:
-        if args.since_days <= 0:
-            raise ValueError("--since-days must be a positive integer")
         past_report = build_past_commit_report(repo_root, config, args.since_days, cases)
         past_report_path = output_dir / f"report-past-{args.since_days}.md"
         past_report_path.write_text(render_past_commit_report(past_report), encoding="utf-8")


### PR DESCRIPTION
## Summary

- Fix 3 workflow-parsing bugs in the ascend CI case diff scan tool
- Extend XML character validation and improve bash target extraction
- Clean up documentation: remove triplication, fix stale references, and restructure for clarity

## Bug Fixes

- **Missing `re.MULTILINE` flag in workflow name regex** — `WORKFLOW_NAME_RE` was compiled without `re.MULTILINE`, causing `^` / `$` anchors to fail when matching multi-line workflow YAML content.
- **Pytest `-k` / `-m` equals-form not recognized** — `_normalize_pytest_signature` only handled space-separated `-k expr` / `-m expr` forms but missed `-k=expr` / `-m=expr`, letting the value leak into the normalized signature.
- **Torchrun flag handling skipped too aggressively** — `extract_torchrun_targets` skipped every flag token unconditionally without checking for `=`-form flags (e.g. `--nproc_per_node=2`), causing test targets that immediately follow a flag to be missed.

## Enhancements

- **XML character validation** — `_is_valid_xml_char` now accepts supplementary-plane Unicode characters (`U+10000`–`U+10FFFF`), preventing `ValueError` from `openpyxl` when sheet content includes emoji or rare CJK characters.
- **Bash target extraction** — `extract_bash_target` now skips flags between `bash` and the script path (e.g. `bash -x script.sh`), instead of assuming the script is always at `idx + 1`.
- **`--since-days` fails fast** — input validation moved before expensive operations, avoiding wasted scans on invalid arguments.
- **YAML file discovery** — `collect_scan_data` now includes both `*.yml` and `*.yaml` workflow files (previously only `*.yml`).

## Documentation

- **Removed content triplication** across `README.md`, `SKILL.md`, and `references/repo-signals.md`. Each file now has a clear role: human overview, agent instruction, and authoritative rule reference.
- **Fixed stale reference** in `repo-signals.md`: primary inputs updated from `*.yml` only to `*.yml` + `*.yaml`.
- **Replaced hardcoded ignore list** in `repo-signals.md` with a reference to `config/workflow_scope.json` to prevent drift.
- **Restructured** the skill `README.md` "Case rules" section into `How cases are classified`, `CLI usage`, and `Past-N-days behavior` subsections.

## Changed Files

| File | Change |
| --- | --- |
| `scripts/modules/workflows.py` | `re.MULTILINE` flag, equals-form `-k`/`-m`, `.yaml` glob |
| `scripts/modules/extractors.py` | Torchrun flag handling, bash flag skipping |
| `scripts/modules/excel.py` | XML supplementary-plane char validation |
| `scripts/scan_ascend_ci_case_diff.py` | Fail-fast `--since-days` validation |
| `README.md` | Restructured Case rules, added CLI usage section |
| `SKILL.md` | Deduplicated, added cross-references to repo-signals |
| `references/repo-signals.md` | Fixed `*.yaml` glob, replaced hardcoded ignore list |

## Type of Change

- [x] Bug fix
- [x] Enhancement
- [x] Documentation
