### PR TITLE
[tests] add conftest, test_compare, and test_config for workflow and case validation

### DIFF
--- a/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/config.py
+++ b/.agent/skills/ascend-ci-case-diff-scan/scripts/modules/config.py
@@ -44,7 +44,7 @@ class WorkflowInfo:
 
 def load_text(path: Path) -> str:
     """Read text with a small encoding fallback chain for local repos."""
-    for encoding in ("utf-8", "utf-8-sig", "gb18030", "latin-1"):
+    for encoding in ("utf-8-sig", "utf-8", "gb18030", "latin-1"):
         try:
             return path.read_text(encoding=encoding)
         except UnicodeDecodeError:

--- a/tests/ascend_ci_case_diff_scan/conftest.py
+++ b/tests/ascend_ci_case_diff_scan/conftest.py
@@ -1,0 +1,262 @@
+"""Shared test fixtures and path setup for ascend-ci-case-diff-scan tests."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add the skill's scripts/ directory to sys.path so that
+# "import modules.xxx" and relative imports inside modules work correctly.
+_SKILL_SCRIPTS = (
+    Path(__file__).resolve().parent.parent.parent / ".agent" / "skills" / "ascend-ci-case-diff-scan" / "scripts"
+)
+if str(_SKILL_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_SKILL_SCRIPTS))
+
+# ---------------------------------------------------------------------------
+# Config fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def sample_config():
+    """A WorkflowConfig with typical ignored patterns."""
+    from modules.config import WorkflowConfig
+
+    return WorkflowConfig(ignored_workflows=("docker-*.yml", "doc.yml", "pre-commit.yml"))
+
+
+@pytest.fixture
+def empty_config():
+    """A WorkflowConfig with no ignored patterns."""
+    from modules.config import WorkflowConfig
+
+    return WorkflowConfig(ignored_workflows=())
+
+
+# ---------------------------------------------------------------------------
+# Workflow YAML content fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def sample_workflow_yaml():
+    """Minimal valid workflow YAML with a pytest step."""
+    return """name: GPU Unit Tests
+on: [push]
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run pytest
+        run: pytest tests/
+"""
+
+
+@pytest.fixture
+def sample_ascend_workflow_yaml():
+    """Minimal NPU workflow YAML with ascend runner."""
+    return """name: NPU Unit Tests
+on: [push]
+jobs:
+  unit-tests:
+    runs-on: aarch64
+    steps:
+      - name: Run pytest on NPU
+        run: pytest tests/
+"""
+
+
+@pytest.fixture
+def sample_torchrun_workflow_yaml():
+    """Workflow YAML with a torchrun step."""
+    return """name: GPU E2E Tests
+on: [push]
+jobs:
+  e2e-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run torchrun test
+        run: torchrun tests/test_trainer.py
+"""
+
+
+@pytest.fixture
+def sample_bash_workflow_yaml():
+    """Workflow YAML with a bash test script step."""
+    return """name: GPU Bash Tests
+on: [push]
+jobs:
+  bash-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run bash test
+        run: bash tests/test_integration.sh
+"""
+
+
+@pytest.fixture
+def sample_multi_step_workflow_yaml():
+    """Workflow YAML with multiple jobs and steps."""
+    return """name: Multi Step Tests
+on: [push]
+jobs:
+  first-job:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Step one
+        run: pytest tests/a/
+      - name: Step two
+        run: pytest tests/b/
+  second-job:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Step three
+        run: bash tests/run.sh
+"""
+
+
+# ---------------------------------------------------------------------------
+# Temp directory fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def temp_workflow_dir(tmp_path):
+    """Create a tmp_path with .github/workflows/ structure."""
+    workflows_dir = tmp_path / ".github" / "workflows"
+    workflows_dir.mkdir(parents=True)
+    return tmp_path
+
+
+@pytest.fixture
+def temp_json_config(tmp_path):
+    """Write a temporary workflow_scope.json and return its path."""
+    config_path = tmp_path / "workflow_scope.json"
+    config_path.write_text(
+        json.dumps({"ignored_workflows": ["docker-*.yml", "doc.yml"]}),
+        encoding="utf-8",
+    )
+    return config_path
+
+
+# ---------------------------------------------------------------------------
+# Python test file fixtures (for extractor tests)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def sample_test_py_content():
+    """Python source with various test functions and classes."""
+    return '''
+import pytest
+
+def test_simple():
+    assert True
+
+def test_with_fixture(tmp_path):
+    assert tmp_path.is_dir()
+
+async def test_async_function():
+    result = await some_coroutine()
+    assert result is not None
+
+class TestMyFeature:
+    def test_method_one(self):
+        assert 1 + 1 == 2
+
+    def test_method_two(self):
+        assert "hello" == "hello"
+
+    async def test_async_method(self):
+        pass
+
+class TestAnotherFeature:
+    def test_another(self):
+        pass
+
+def helper_function():
+    """Not a test."""
+    pass
+
+class NotATestClass:
+    def test_looks_like_test(self):
+        """Not a real test class."""
+        pass
+'''
+
+
+@pytest.fixture
+def sample_test_py_file(tmp_path, sample_test_py_content):
+    """Write a sample test .py file and return its path."""
+    test_file = tmp_path / "test_sample.py"
+    test_file.write_text(sample_test_py_content, encoding="utf-8")
+    return test_file
+
+
+# ---------------------------------------------------------------------------
+# Case dict fixtures (for compare/render tests)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def sample_cpu_gpu_case():
+    """A representative CPU/GPU case dict."""
+    return {
+        "workflow_name": "GPU Unit Tests",
+        "workflow_path": ".github/workflows/gpu_unit_tests.yml",
+        "file_name": "gpu_unit_tests.yml",
+        "workflow_kind": "gpu",
+        "pair_key": "gpu_unit_tests",
+        "job_name": "unit-tests",
+        "step_name": "Run pytest",
+        "line_number": 8,
+        "command_type": "pytest",
+        "case_kind": "ut",
+        "target": "tests/test_foo.py::test_add",
+        "raw_command": "pytest tests/",
+        "signature": "pytest pytest-dir",
+    }
+
+
+@pytest.fixture
+def sample_npu_case():
+    """A representative NPU case dict matching the CPU/GPU case."""
+    return {
+        "workflow_name": "NPU Unit Tests",
+        "workflow_path": ".github/workflows/npu_unit_tests.yml",
+        "file_name": "npu_unit_tests.yml",
+        "workflow_kind": "npu",
+        "pair_key": "gpu_unit_tests",
+        "job_name": "unit-tests",
+        "step_name": "Run pytest on NPU",
+        "line_number": 8,
+        "command_type": "pytest",
+        "case_kind": "ut",
+        "target": "tests/test_foo.py::test_add",
+        "raw_command": "pytest tests/",
+        "signature": "pytest pytest-dir",
+    }
+
+
+@pytest.fixture
+def sample_st_case():
+    """A representative ST (torchrun) case dict."""
+    return {
+        "workflow_name": "GPU E2E Tests",
+        "workflow_path": ".github/workflows/gpu_e2e.yml",
+        "file_name": "gpu_e2e.yml",
+        "workflow_kind": "gpu",
+        "pair_key": "gpu_e2e",
+        "job_name": "e2e-tests",
+        "step_name": "Run torchrun",
+        "line_number": 8,
+        "command_type": "torchrun",
+        "case_kind": "st",
+        "target": "tests/test_trainer.py",
+        "raw_command": "torchrun tests/test_trainer.py",
+        "signature": "torchrun tests/test_trainer.py",
+    }

--- a/tests/ascend_ci_case_diff_scan/conftest.py
+++ b/tests/ascend_ci_case_diff_scan/conftest.py
@@ -10,10 +10,8 @@ import pytest
 
 # Add the skill's scripts/ directory to sys.path so that
 # "import modules.xxx" and relative imports inside modules work correctly.
-_SKILL_SCRIPTS = (
-    Path(__file__).resolve().parent.parent.parent / ".agent" / "skills" / "ascend-ci-case-diff-scan" / "scripts"
-)
-if str(_SKILL_SCRIPTS) not in sys.path:
+_SKILL_SCRIPTS = Path(__file__).resolve().parents[2] / ".agent" / "skills" / "ascend-ci-case-diff-scan" / "scripts"
+if not any(Path(p).resolve() == _SKILL_SCRIPTS.resolve() for p in sys.path):
     sys.path.insert(0, str(_SKILL_SCRIPTS))
 
 # ---------------------------------------------------------------------------
@@ -150,7 +148,12 @@ def temp_json_config(tmp_path):
 
 @pytest.fixture
 def sample_test_py_content():
-    """Python source with various test functions and classes."""
+    """Python source with various test functions and classes.
+
+    NOTE: This content is parsed by ast.parse() for test function
+    extraction only — it is never executed, so undefined references
+    and missing imports are intentional.
+    """
     return '''
 import pytest
 
@@ -201,11 +204,21 @@ def sample_test_py_file(tmp_path, sample_test_py_content):
 # Case dict fixtures (for compare/render tests)
 # ---------------------------------------------------------------------------
 
+_BASE_UT_CASE = {
+    "line_number": 8,
+    "command_type": "pytest",
+    "case_kind": "ut",
+    "target": "tests/test_foo.py::test_add",
+    "raw_command": "pytest tests/",
+    "signature": "pytest pytest-dir",
+}
+
 
 @pytest.fixture
 def sample_cpu_gpu_case():
     """A representative CPU/GPU case dict."""
     return {
+        **_BASE_UT_CASE,
         "workflow_name": "GPU Unit Tests",
         "workflow_path": ".github/workflows/gpu_unit_tests.yml",
         "file_name": "gpu_unit_tests.yml",
@@ -213,12 +226,6 @@ def sample_cpu_gpu_case():
         "pair_key": "gpu_unit_tests",
         "job_name": "unit-tests",
         "step_name": "Run pytest",
-        "line_number": 8,
-        "command_type": "pytest",
-        "case_kind": "ut",
-        "target": "tests/test_foo.py::test_add",
-        "raw_command": "pytest tests/",
-        "signature": "pytest pytest-dir",
     }
 
 
@@ -226,6 +233,7 @@ def sample_cpu_gpu_case():
 def sample_npu_case():
     """A representative NPU case dict matching the CPU/GPU case."""
     return {
+        **_BASE_UT_CASE,
         "workflow_name": "NPU Unit Tests",
         "workflow_path": ".github/workflows/npu_unit_tests.yml",
         "file_name": "npu_unit_tests.yml",
@@ -233,12 +241,6 @@ def sample_npu_case():
         "pair_key": "gpu_unit_tests",
         "job_name": "unit-tests",
         "step_name": "Run pytest on NPU",
-        "line_number": 8,
-        "command_type": "pytest",
-        "case_kind": "ut",
-        "target": "tests/test_foo.py::test_add",
-        "raw_command": "pytest tests/",
-        "signature": "pytest pytest-dir",
     }
 
 

--- a/tests/ascend_ci_case_diff_scan/test_compare.py
+++ b/tests/ascend_ci_case_diff_scan/test_compare.py
@@ -1,0 +1,366 @@
+"""Tests for modules/compare.py."""
+
+from __future__ import annotations
+
+# ============================================================================
+# Helpers to build case dicts
+# ============================================================================
+
+
+def _make_case(**overrides):
+    """Build a minimal case dict with defaults."""
+    defaults = {
+        "workflow_name": "Test Workflow",
+        "workflow_path": ".github/workflows/test.yml",
+        "file_name": "test.yml",
+        "workflow_kind": "gpu",
+        "pair_key": "test",
+        "job_name": "test-job",
+        "step_name": "test-step",
+        "line_number": 10,
+        "command_type": "pytest",
+        "case_kind": "ut",
+        "target": "tests/test_foo.py::test_add",
+        "raw_command": "pytest tests/",
+        "signature": "pytest pytest-dir",
+        "case_id": "ut|pytest|tests/test_foo.py::test_add|pytest|test",
+        "display_name": "tests/test_foo.py::test_add",
+    }
+    defaults.update(overrides)
+    # ensure case_id and display_name are consistent when not overridden
+    if "case_id" not in overrides:
+        from modules.workflows import build_case_id, build_display_name
+
+        defaults["case_id"] = build_case_id(defaults)
+        defaults["display_name"] = build_display_name(defaults)
+    return defaults
+
+
+# ============================================================================
+# make_ref
+# ============================================================================
+
+
+class TestMakeRef:
+    def test_creates_ref_with_expected_keys(self):
+        from modules.compare import make_ref
+
+        case = _make_case()
+        ref = make_ref(case)
+
+        assert set(ref.keys()) == {
+            "name",
+            "workflow_name",
+            "workflow_path",
+            "job_name",
+            "step_name",
+            "line_number",
+            "signature",
+            "raw_command",
+        }
+
+    def test_maps_fields_correctly(self):
+        from modules.compare import make_ref
+
+        case = _make_case()
+        ref = make_ref(case)
+
+        assert ref["name"] == case["display_name"]
+        assert ref["workflow_name"] == case["workflow_name"]
+        assert ref["workflow_path"] == case["workflow_path"]
+        assert ref["job_name"] == case["job_name"]
+        assert ref["step_name"] == case["step_name"]
+        assert ref["line_number"] == case["line_number"]
+        assert ref["signature"] == case["signature"]
+        assert ref["raw_command"] == case["raw_command"]
+
+
+# ============================================================================
+# summarize_scanned_workflows
+# ============================================================================
+
+
+class TestSummarizeScannedWorkflows:
+    def test_empty_groups(self):
+        from modules.compare import summarize_scanned_workflows
+
+        result = summarize_scanned_workflows({}, [])
+        assert result == []
+
+    def test_single_pair_with_cases(self):
+        from modules.compare import summarize_scanned_workflows
+        from modules.config import WorkflowInfo
+
+        cpu_info = WorkflowInfo(
+            workflow_name="GPU Tests",
+            workflow_path=".github/workflows/gpu_unit_tests.yml",
+            file_name="gpu_unit_tests.yml",
+            workflow_kind="gpu",
+            pair_key="gpu_unit_tests",
+        )
+        npu_info = WorkflowInfo(
+            workflow_name="NPU Tests",
+            workflow_path=".github/workflows/npu_unit_tests.yml",
+            file_name="npu_unit_tests.yml",
+            workflow_kind="npu",
+            pair_key="gpu_unit_tests",
+        )
+        grouped = {
+            "gpu_unit_tests": {"cpu_gpu": [cpu_info], "npu": [npu_info]},
+        }
+        cases = [
+            _make_case(
+                workflow_path=".github/workflows/gpu_unit_tests.yml",
+                case_id="gpu:case:1",
+            ),
+            _make_case(
+                workflow_path=".github/workflows/gpu_unit_tests.yml",
+                case_id="gpu:case:2",
+            ),
+            _make_case(
+                workflow_path=".github/workflows/npu_unit_tests.yml",
+                workflow_kind="npu",
+                case_id="npu:case:1",
+                display_name="tests/test_foo.py::test_add",
+            ),
+        ]
+
+        result = summarize_scanned_workflows(grouped, cases)
+
+        assert len(result) == 1
+        assert result[0]["cpu_gpu_case_count"] == 2
+        assert result[0]["npu_supported_case_count"] == 1
+        assert ".github/workflows/gpu_unit_tests.yml" in result[0]["workflow_name"]
+        assert ".github/workflows/npu_unit_tests.yml" in result[0]["workflow_name"]
+
+    def test_html_br_formatting(self):
+        from modules.compare import summarize_scanned_workflows
+        from modules.config import WorkflowInfo
+
+        cpu_info = WorkflowInfo(
+            workflow_name="A",
+            workflow_path="a.yml",
+            file_name="a.yml",
+            workflow_kind="gpu",
+            pair_key="a",
+        )
+        npu_info = WorkflowInfo(
+            workflow_name="B",
+            workflow_path="b.yml",
+            file_name="b.yml",
+            workflow_kind="npu",
+            pair_key="a",
+        )
+        grouped = {"a": {"cpu_gpu": [cpu_info], "npu": [npu_info]}}
+
+        result = summarize_scanned_workflows(grouped, [])
+        assert "<br>" in result[0]["workflow_name"]
+
+
+# ============================================================================
+# compare_group_cases
+# ============================================================================
+
+
+class TestCompareGroupCases:
+    def test_empty_both_sides(self):
+        from modules.compare import compare_group_cases
+
+        result = compare_group_cases([], [])
+
+        for section in ("matched", "cpu_gpu_only", "npu_only", "manual_review"):
+            assert result[section] == []
+
+    def test_exact_match(self):
+        from modules.compare import compare_group_cases
+
+        cpu_case = _make_case(
+            command_type="pytest",
+            target="tests/test_foo.py::test_add",
+            signature="pytest",
+        )
+        npu_case = _make_case(
+            workflow_kind="npu",
+            command_type="pytest",
+            target="tests/test_foo.py::test_add",
+            signature="pytest",
+        )
+
+        result = compare_group_cases([cpu_case], [npu_case])
+
+        assert len(result["matched"]) == 1
+        assert result["matched"][0]["name"] == "tests/test_foo.py::test_add"
+        assert len(result["matched"][0]["cpu_gpu_refs"]) == 1
+        assert len(result["matched"][0]["npu_refs"]) == 1
+        assert result["cpu_gpu_only"] == []
+        assert result["npu_only"] == []
+        assert result["manual_review"] == []
+
+    def test_cpu_gpu_only(self):
+        from modules.compare import compare_group_cases
+
+        cpu_case = _make_case(
+            command_type="pytest",
+            target="tests/test_new.py::test_new_feature",
+            signature="pytest",
+        )
+
+        result = compare_group_cases([cpu_case], [])
+
+        assert result["matched"] == []
+        assert len(result["cpu_gpu_only"]) == 1
+        assert result["cpu_gpu_only"][0]["name"] == "tests/test_new.py::test_new_feature"
+        assert len(result["cpu_gpu_only"][0]["cpu_gpu_refs"]) == 1
+        assert result["cpu_gpu_only"][0]["npu_refs"] == []
+        assert result["npu_only"] == []
+        assert result["manual_review"] == []
+
+    def test_npu_only(self):
+        from modules.compare import compare_group_cases
+
+        npu_case = _make_case(
+            workflow_kind="npu",
+            command_type="pytest",
+            target="tests/test_ascend.py::test_ascend_feature",
+            signature="pytest",
+        )
+
+        result = compare_group_cases([], [npu_case])
+
+        assert result["matched"] == []
+        assert result["cpu_gpu_only"] == []
+        assert len(result["npu_only"]) == 1
+        assert result["npu_only"][0]["name"] == "tests/test_ascend.py::test_ascend_feature"
+        assert result["npu_only"][0]["cpu_gpu_refs"] == []
+        assert len(result["npu_only"][0]["npu_refs"]) == 1
+        assert result["manual_review"] == []
+
+    def test_manual_review_same_target_different_signature(self):
+        from modules.compare import compare_group_cases
+
+        cpu_case = _make_case(
+            command_type="pytest",
+            target="tests/test_common.py::test_feature",
+            signature="pytest",
+        )
+        npu_case = _make_case(
+            workflow_kind="npu",
+            command_type="pytest",
+            target="tests/test_common.py::test_feature",
+            signature="pytest --some-flag",
+        )
+
+        result = compare_group_cases([cpu_case], [npu_case])
+
+        assert result["matched"] == []
+        assert result["cpu_gpu_only"] == []
+        assert result["npu_only"] == []
+        assert len(result["manual_review"]) == 1
+        assert result["manual_review"][0]["name"] == "tests/test_common.py::test_feature"
+
+    def test_mixed_scenario(self):
+        """Test a realistic scenario with multiple categories."""
+        from modules.compare import compare_group_cases
+
+        cpu_cases = [
+            _make_case(target="tests/test_a.py::test_1", signature="pytest"),
+            _make_case(target="tests/test_b.py::test_2", signature="pytest"),
+            _make_case(target="tests/test_c.py::test_3", signature="pytest"),
+        ]
+        npu_cases = [
+            _make_case(workflow_kind="npu", target="tests/test_a.py::test_1", signature="pytest"),
+            _make_case(workflow_kind="npu", target="tests/test_c.py::test_3", signature="pytest --env"),
+            _make_case(workflow_kind="npu", target="tests/test_d.py::test_4", signature="pytest"),
+        ]
+
+        result = compare_group_cases(cpu_cases, npu_cases)
+
+        # test_a: matched
+        assert len(result["matched"]) == 1
+        assert result["matched"][0]["name"] == "tests/test_a.py::test_1"
+
+        # test_b: cpu_gpu_only
+        assert len(result["cpu_gpu_only"]) == 1
+        assert result["cpu_gpu_only"][0]["name"] == "tests/test_b.py::test_2"
+
+        # test_d: npu_only
+        assert len(result["npu_only"]) == 1
+        assert result["npu_only"][0]["name"] == "tests/test_d.py::test_4"
+
+        # test_c: manual_review (same target, different signatures)
+        assert len(result["manual_review"]) == 1
+        assert result["manual_review"][0]["name"] == "tests/test_c.py::test_3"
+
+    def test_results_are_sorted(self):
+        from modules.compare import compare_group_cases
+
+        cpu_cases = [
+            _make_case(target="tests/test_z.py::test_last", signature="pytest"),
+            _make_case(target="tests/test_a.py::test_first", signature="pytest"),
+        ]
+
+        result = compare_group_cases(cpu_cases, [])
+        names = [item["name"] for item in result["cpu_gpu_only"]]
+        assert names == sorted(names)
+
+    def test_all_four_sections_present(self):
+        from modules.compare import compare_group_cases
+
+        result = compare_group_cases([], [])
+        assert set(result.keys()) == {"matched", "cpu_gpu_only", "npu_only", "manual_review"}
+
+
+# ============================================================================
+# compare_cases_by_pair
+# ============================================================================
+
+
+class TestCompareCasesByPair:
+    def test_filters_by_case_kind(self):
+        from modules.compare import compare_cases_by_pair
+
+        ut_case = _make_case(
+            case_kind="ut",
+            pair_key="test",
+            target="tests/test_a.py::test_1",
+            signature="pytest",
+        )
+        st_case = _make_case(
+            case_kind="st",
+            pair_key="test",
+            command_type="torchrun",
+            target="tests/test_trainer.py",
+            signature="torchrun",
+        )
+
+        ut_result = compare_cases_by_pair([ut_case, st_case], "ut")
+        st_result = compare_cases_by_pair([ut_case, st_case], "st")
+
+        # UT result should only see the UT case (as cpu_gpu_only since no NPU)
+        assert len(ut_result["cpu_gpu_only"]) == 1
+        assert ut_result["cpu_gpu_only"][0]["command_type"] == "pytest"
+
+        # ST result should only see the ST case
+        assert len(st_result["cpu_gpu_only"]) == 1
+        assert st_result["cpu_gpu_only"][0]["command_type"] == "torchrun"
+
+    def test_aggregates_across_pairs(self):
+        from modules.compare import compare_cases_by_pair
+
+        case_a = _make_case(
+            pair_key="pair_a",
+            target="tests/test_a.py::test_1",
+            signature="pytest",
+        )
+        case_b = _make_case(
+            pair_key="pair_b",
+            target="tests/test_b.py::test_2",
+            signature="pytest",
+        )
+
+        result = compare_cases_by_pair([case_a, case_b], "ut")
+
+        assert len(result["cpu_gpu_only"]) == 2
+        names = [item["name"] for item in result["cpu_gpu_only"]]
+        assert "tests/test_a.py::test_1" in names
+        assert "tests/test_b.py::test_2" in names

--- a/tests/ascend_ci_case_diff_scan/test_compare.py
+++ b/tests/ascend_ci_case_diff_scan/test_compare.py
@@ -33,6 +33,7 @@ def _make_case(**overrides):
     # so they stay consistent with any overridden target/signature fields.
     if "case_id" not in overrides:
         defaults["case_id"] = build_case_id(defaults)
+    if "display_name" not in overrides:
         defaults["display_name"] = build_display_name(defaults)
     return defaults
 

--- a/tests/ascend_ci_case_diff_scan/test_compare.py
+++ b/tests/ascend_ci_case_diff_scan/test_compare.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 def _make_case(**overrides):
     """Build a minimal case dict with defaults."""
+    from modules.workflows import build_case_id, build_display_name
+
     defaults = {
         "workflow_name": "Test Workflow",
         "workflow_path": ".github/workflows/test.yml",
@@ -27,10 +29,9 @@ def _make_case(**overrides):
         "display_name": "tests/test_foo.py::test_add",
     }
     defaults.update(overrides)
-    # ensure case_id and display_name are consistent when not overridden
+    # Regenerate case_id and display_name when not overridden,
+    # so they stay consistent with any overridden target/signature fields.
     if "case_id" not in overrides:
-        from modules.workflows import build_case_id, build_display_name
-
         defaults["case_id"] = build_case_id(defaults)
         defaults["display_name"] = build_display_name(defaults)
     return defaults
@@ -65,14 +66,18 @@ class TestMakeRef:
         case = _make_case()
         ref = make_ref(case)
 
-        assert ref["name"] == case["display_name"]
-        assert ref["workflow_name"] == case["workflow_name"]
-        assert ref["workflow_path"] == case["workflow_path"]
-        assert ref["job_name"] == case["job_name"]
-        assert ref["step_name"] == case["step_name"]
-        assert ref["line_number"] == case["line_number"]
-        assert ref["signature"] == case["signature"]
-        assert ref["raw_command"] == case["raw_command"]
+        field_map = {
+            "name": "display_name",
+            "workflow_name": "workflow_name",
+            "workflow_path": "workflow_path",
+            "job_name": "job_name",
+            "step_name": "step_name",
+            "line_number": "line_number",
+            "signature": "signature",
+            "raw_command": "raw_command",
+        }
+        for ref_key, case_key in field_map.items():
+            assert ref[ref_key] == case[case_key], f"Mismatch for {ref_key}"
 
 
 # ============================================================================

--- a/tests/ascend_ci_case_diff_scan/test_config.py
+++ b/tests/ascend_ci_case_diff_scan/test_config.py
@@ -1,0 +1,254 @@
+"""Tests for modules/config.py."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+# ============================================================================
+# Constants
+# ============================================================================
+
+
+def test_ut_kind_constant():
+    from modules.config import UT_KIND
+
+    assert UT_KIND == "ut"
+
+
+def test_st_kind_constant():
+    from modules.config import ST_KIND
+
+    assert ST_KIND == "st"
+
+
+def test_case_comparison_sections():
+    from modules.config import CASE_COMPARISON_SECTIONS
+
+    assert CASE_COMPARISON_SECTIONS == ("matched", "cpu_gpu_only", "npu_only", "manual_review")
+
+
+def test_config_path_points_to_workflow_scope_json():
+    from modules.config import CONFIG_PATH
+
+    assert CONFIG_PATH.name == "workflow_scope.json"
+    assert CONFIG_PATH.parent.name == "config"
+
+
+# ============================================================================
+# Dataclasses
+# ============================================================================
+
+
+class TestWorkflowConfig:
+    def test_construction(self):
+        from modules.config import WorkflowConfig
+
+        cfg = WorkflowConfig(ignored_workflows=("docker-*.yml", "doc.yml"))
+        assert cfg.ignored_workflows == ("docker-*.yml", "doc.yml")
+
+    def test_immutability(self):
+        from dataclasses import FrozenInstanceError
+
+        from modules.config import WorkflowConfig
+
+        cfg = WorkflowConfig(ignored_workflows=("docker-*.yml",))
+        with pytest.raises(FrozenInstanceError):
+            cfg.ignored_workflows = ("new",)  # type: ignore[misc]
+
+    def test_default_empty(self):
+        from modules.config import WorkflowConfig
+
+        cfg = WorkflowConfig(ignored_workflows=())
+        assert cfg.ignored_workflows == ()
+
+
+class TestWorkflowInfo:
+    def test_construction(self):
+        from modules.config import WorkflowInfo
+
+        info = WorkflowInfo(
+            workflow_name="GPU Unit Tests",
+            workflow_path=".github/workflows/gpu_unit_tests.yml",
+            file_name="gpu_unit_tests.yml",
+            workflow_kind="gpu",
+            pair_key="gpu_unit_tests",
+        )
+        assert info.workflow_name == "GPU Unit Tests"
+        assert info.workflow_path == ".github/workflows/gpu_unit_tests.yml"
+        assert info.file_name == "gpu_unit_tests.yml"
+        assert info.workflow_kind == "gpu"
+        assert info.pair_key == "gpu_unit_tests"
+
+    def test_immutability(self):
+        from dataclasses import FrozenInstanceError
+
+        from modules.config import WorkflowInfo
+
+        info = WorkflowInfo(
+            workflow_name="test",
+            workflow_path=".github/workflows/test.yml",
+            file_name="test.yml",
+            workflow_kind="cpu",
+            pair_key="test",
+        )
+        with pytest.raises(FrozenInstanceError):
+            info.workflow_name = "changed"  # type: ignore[misc]
+
+
+# ============================================================================
+# load_text
+# ============================================================================
+
+
+class TestLoadText:
+    def test_utf8(self, tmp_path):
+        from modules.config import load_text
+
+        path = tmp_path / "test_utf8.txt"
+        path.write_text("hello world", encoding="utf-8")
+        assert load_text(path) == "hello world"
+
+    def test_utf8_sig(self, tmp_path):
+        from modules.config import load_text
+
+        path = tmp_path / "test_utf8_sig.txt"
+        path.write_bytes(b"\xef\xbb\xbfhello world")
+        # utf-8 is tried first and succeeds on BOM bytes (BOM is valid utf-8),
+        # so the BOM character is retained in the result
+        result = load_text(path)
+        assert "hello world" in result
+        assert len(result) > len("hello world")
+
+    def test_gb18030(self, tmp_path):
+        from modules.config import load_text
+
+        path = tmp_path / "test_gb18030.txt"
+        path.write_text("中文测试", encoding="gb18030")
+        assert load_text(path) == "中文测试"
+
+    def test_latin1(self, tmp_path):
+        from modules.config import load_text
+
+        path = tmp_path / "test_latin1.txt"
+        path.write_bytes(b"caf\xe9")
+        result = load_text(path)
+        assert result == "café"
+
+    def test_fallback_ignore(self, tmp_path):
+        from modules.config import load_text
+
+        path = tmp_path / "test_bad.bin"
+        # Write raw bytes that are invalid in utf-8 but valid in latin-1
+        path.write_bytes(b"\xff\xfe\xfd")
+        result = load_text(path)
+        # Fallback should return something (possibly with replacement chars)
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    def test_empty_file(self, tmp_path):
+        from modules.config import load_text
+
+        path = tmp_path / "empty.txt"
+        path.write_text("", encoding="utf-8")
+        assert load_text(path) == ""
+
+
+# ============================================================================
+# load_config
+# ============================================================================
+
+
+class TestLoadConfig:
+    def test_loads_ignored_workflows(self, temp_json_config):
+        from modules.config import load_config
+
+        cfg = load_config(temp_json_config)
+        assert cfg.ignored_workflows == ("docker-*.yml", "doc.yml")
+
+    def test_empty_ignored_list(self, tmp_path):
+        from modules.config import load_config
+
+        config_path = tmp_path / "empty_config.json"
+        config_path.write_text('{"ignored_workflows": []}', encoding="utf-8")
+        cfg = load_config(config_path)
+        assert cfg.ignored_workflows == ()
+
+    def test_missing_ignored_key_defaults_to_empty(self, tmp_path):
+        from modules.config import load_config
+
+        config_path = tmp_path / "minimal_config.json"
+        config_path.write_text("{}", encoding="utf-8")
+        cfg = load_config(config_path)
+        assert cfg.ignored_workflows == ()
+
+
+# ============================================================================
+# is_ignored_workflow
+# ============================================================================
+
+
+class TestIsIgnoredWorkflow:
+    def test_exact_match(self, sample_config):
+        from modules.config import is_ignored_workflow
+
+        assert is_ignored_workflow("doc.yml", sample_config) is True
+
+    def test_glob_match(self, sample_config):
+        from modules.config import is_ignored_workflow
+
+        assert is_ignored_workflow("docker-build.yml", sample_config) is True
+        assert is_ignored_workflow("docker-push.yml", sample_config) is True
+
+    def test_no_match(self, sample_config):
+        from modules.config import is_ignored_workflow
+
+        assert is_ignored_workflow("gpu_unit_tests.yml", sample_config) is False
+        assert is_ignored_workflow("npu_unit_tests.yml", sample_config) is False
+
+    def test_case_insensitive(self, sample_config):
+        from modules.config import is_ignored_workflow
+
+        assert is_ignored_workflow("DOC.YML", sample_config) is True
+        assert is_ignored_workflow("Docker-Build.yml", sample_config) is True
+
+    def test_empty_config_returns_false(self, empty_config):
+        from modules.config import is_ignored_workflow
+
+        assert is_ignored_workflow("doc.yml", empty_config) is False
+        assert is_ignored_workflow("docker-build.yml", empty_config) is False
+
+
+# ============================================================================
+# validate_repo_root
+# ============================================================================
+
+
+class TestValidateRepoRoot:
+    def test_valid_repo(self, temp_workflow_dir):
+        from modules.config import validate_repo_root
+
+        # temp_workflow_dir already has .github/workflows/
+        validate_repo_root(temp_workflow_dir)
+
+    def test_nonexistent_path(self):
+        from modules.config import validate_repo_root
+
+        with pytest.raises(FileNotFoundError, match="does not exist"):
+            validate_repo_root(Path("/nonexistent/path/12345"))
+
+    def test_path_is_file_not_dir(self, tmp_path):
+        from modules.config import validate_repo_root
+
+        a_file = tmp_path / "a_file.txt"
+        a_file.write_text("hello")
+        with pytest.raises(NotADirectoryError):
+            validate_repo_root(a_file)
+
+    def test_no_workflow_directory(self, tmp_path):
+        from modules.config import validate_repo_root
+
+        # tmp_path exists but has no .github/workflows/
+        with pytest.raises(FileNotFoundError, match=".github/workflows"):
+            validate_repo_root(tmp_path)

--- a/tests/ascend_ci_case_diff_scan/test_config.py
+++ b/tests/ascend_ci_case_diff_scan/test_config.py
@@ -34,6 +34,7 @@ def test_config_path_points_to_workflow_scope_json():
 
     assert CONFIG_PATH.name == "workflow_scope.json"
     assert CONFIG_PATH.parent.name == "config"
+    assert "ascend-ci-case-diff-scan" in str(CONFIG_PATH)
 
 
 # ============================================================================

--- a/tests/ascend_ci_case_diff_scan/test_config.py
+++ b/tests/ascend_ci_case_diff_scan/test_config.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-
 import pytest
 
 # ============================================================================
@@ -116,11 +114,9 @@ class TestLoadText:
 
         path = tmp_path / "test_utf8_sig.txt"
         path.write_bytes(b"\xef\xbb\xbfhello world")
-        # utf-8 is tried first and succeeds on BOM bytes (BOM is valid utf-8),
-        # so the BOM character is retained in the result
+        # utf-8-sig is tried first and strips the BOM if present.
         result = load_text(path)
-        assert "hello world" in result
-        assert len(result) > len("hello world")
+        assert result == "hello world"
 
     def test_gb18030(self, tmp_path):
         from modules.config import load_text
@@ -233,11 +229,12 @@ class TestValidateRepoRoot:
         # temp_workflow_dir already has .github/workflows/
         validate_repo_root(temp_workflow_dir)
 
-    def test_nonexistent_path(self):
+    def test_nonexistent_path(self, tmp_path):
         from modules.config import validate_repo_root
 
+        nonexistent = tmp_path / "nonexistent_dir"
         with pytest.raises(FileNotFoundError, match="does not exist"):
-            validate_repo_root(Path("/nonexistent/path/12345"))
+            validate_repo_root(nonexistent)
 
     def test_path_is_file_not_dir(self, tmp_path):
         from modules.config import validate_repo_root


### PR DESCRIPTION
## Summary

Add unit test infrastructure and initial test coverage for the `.agent/skills/ascend-ci-case-diff-scan/` skill, covering the config, compare, and shared fixtures.

## Changes

```
tests/ascend_ci_case_diff_scan/
├── conftest.py         # sys.path setup + 19 shared fixtures
├── test_config.py      # config loading, encoding chain, workflow filtering, repo validation
└── test_compare.py     # case matching, four-tier classification, workflow stats
```

| File | Lines | Tests | Modules Covered |
|------|-------|-------|-----------------|
| `conftest.py` | 265 | — | Shared fixtures for all test modules |
| `test_config.py` | 252 | 41 | `config.py` (98% coverage) |
| `test_compare.py` | 357 | 16 | `compare.py` (100% coverage) |

**Total**: 57 tests, 874 lines