### PR TITLE
[tests] add test_extractors, test_past_commits, and test_workflows for ascend-ci-case-diff-scan

### DIFF
--- a/tests/ascend_ci_case_diff_scan/test_extractors.py
+++ b/tests/ascend_ci_case_diff_scan/test_extractors.py
@@ -1,0 +1,528 @@
+"""Tests for modules/extractors.py."""
+
+from __future__ import annotations
+
+import ast
+
+import pytest
+
+# ============================================================================
+# normalize_path_text
+# ============================================================================
+
+
+class TestNormalizePathText:
+    def test_backslash_to_slash(self):
+        from modules.extractors import normalize_path_text
+
+        assert normalize_path_text("tests\\test_foo.py") == "tests/test_foo.py"
+
+    def test_strip_whitespace(self):
+        from modules.extractors import normalize_path_text
+
+        assert normalize_path_text("  tests/test_foo.py  ") == "tests/test_foo.py"
+
+    def test_mixed_separators(self):
+        from modules.extractors import normalize_path_text
+
+        assert normalize_path_text("tests\\a/b\\c") == "tests/a/b/c"
+
+    def test_no_change(self):
+        from modules.extractors import normalize_path_text
+
+        assert normalize_path_text("tests/test_foo.py") == "tests/test_foo.py"
+
+    def test_empty_string(self):
+        from modules.extractors import normalize_path_text
+
+        assert normalize_path_text("") == ""
+
+    def test_only_backslashes(self):
+        from modules.extractors import normalize_path_text
+
+        assert normalize_path_text("\\\\") == "//"
+
+
+# ============================================================================
+# extract_pytest_specs
+# ============================================================================
+
+
+class TestExtractPytestSpecs:
+    def test_simple_pytest_directory(self):
+        from modules.extractors import extract_pytest_specs
+
+        targets, ignore_paths, ignore_globs = extract_pytest_specs(["pytest", "tests/"], 0)
+        assert targets == ["tests/"]
+
+    def test_pytest_with_specific_file(self):
+        from modules.extractors import extract_pytest_specs
+
+        targets, ignore_paths, ignore_globs = extract_pytest_specs(["pytest", "tests/test_foo.py"], 0)
+        assert targets == ["tests/test_foo.py"]
+
+    def test_pytest_with_ignore_option(self):
+        from modules.extractors import extract_pytest_specs
+
+        targets, ignore_paths, ignore_globs = extract_pytest_specs(
+            ["pytest", "tests/", "--ignore", "tests/skip_this.py"], 0
+        )
+        assert "tests/skip_this.py" in ignore_paths
+        assert "tests/" in targets
+
+    def test_pytest_with_ignore_glob_option(self):
+        from modules.extractors import extract_pytest_specs
+
+        targets, ignore_paths, ignore_globs = extract_pytest_specs(
+            ["pytest", "tests/", "--ignore-glob", "tests/*/deprecated/*"], 0
+        )
+        assert "tests/*/deprecated/*" in ignore_globs
+
+    def test_pytest_with_inline_ignore(self):
+        from modules.extractors import extract_pytest_specs
+
+        targets, ignore_paths, ignore_globs = extract_pytest_specs(["pytest", "--ignore=tests/skip.py", "tests/"], 0)
+        assert "tests/skip.py" in ignore_paths
+        assert "tests/" in targets
+
+    def test_pytest_with_inline_ignore_glob(self):
+        from modules.extractors import extract_pytest_specs
+
+        targets, ignore_paths, ignore_globs = extract_pytest_specs(["pytest", "--ignore-glob=tests/bad/*", "tests/"], 0)
+        assert "tests/bad/*" in ignore_globs
+
+    def test_pytest_with_k_option_skipped(self):
+        from modules.extractors import extract_pytest_specs
+
+        targets, _, _ = extract_pytest_specs(["pytest", "-k", "test_foo", "tests/"], 0)
+        # -k value should not appear in targets
+        assert "test_foo" not in targets
+        assert "tests/" in targets
+
+    def test_pytest_with_m_option_skipped(self):
+        from modules.extractors import extract_pytest_specs
+
+        targets, _, _ = extract_pytest_specs(["pytest", "-m", "slow", "tests/"], 0)
+        assert "slow" not in targets
+        assert "tests/" in targets
+
+    def test_pytest_with_maxfail_skipped(self):
+        from modules.extractors import extract_pytest_specs
+
+        targets, _, _ = extract_pytest_specs(["pytest", "--maxfail", "5", "tests/"], 0)
+        assert "5" not in targets
+
+    def test_pytest_no_targets(self):
+        from modules.extractors import extract_pytest_specs
+
+        targets, ignore_paths, ignore_globs = extract_pytest_specs(["pytest", "-v"], 0)
+        assert targets == []
+
+    def test_pytest_flag_starting_with_dash_not_target(self):
+        from modules.extractors import extract_pytest_specs
+
+        targets, _, _ = extract_pytest_specs(["pytest", "-x", "--tb=short", "tests/"], 0)
+        assert "-x" not in targets
+        assert "--tb=short" not in targets
+        assert "tests/" in targets
+
+    def test_quoted_ignore_value(self):
+        from modules.extractors import extract_pytest_specs
+
+        targets, ignore_paths, _ = extract_pytest_specs(["pytest", "tests/", "--ignore", '"tests/quoted.py"'], 0)
+        assert "tests/quoted.py" in ignore_paths
+
+
+# ============================================================================
+# extract_torchrun_targets
+# ============================================================================
+
+
+class TestExtractTorchrunTargets:
+    def test_extracts_test_target(self):
+        from modules.extractors import extract_torchrun_targets
+
+        result = extract_torchrun_targets(["torchrun", "tests/test_trainer.py"], 0)
+        assert result == ["tests/test_trainer.py"]
+
+    def test_torchrun_with_m_pytest_returns_empty(self):
+        from modules.extractors import extract_torchrun_targets
+
+        # torchrun -m pytest means pytest mode, not torchrun targets
+        result = extract_torchrun_targets(["torchrun", "-m", "pytest", "tests/"], 0)
+        assert result == []
+
+    def test_torchrun_with_flags_skipped(self):
+        from modules.extractors import extract_torchrun_targets
+
+        result = extract_torchrun_targets(["torchrun", "--nproc_per_node", "4", "tests/test_trainer.py"], 0)
+        assert result == ["tests/test_trainer.py"]
+
+    def test_no_tests_targets(self):
+        from modules.extractors import extract_torchrun_targets
+
+        result = extract_torchrun_targets(["torchrun", "--version"], 0)
+        assert result == []
+
+
+# ============================================================================
+# extract_bash_target
+# ============================================================================
+
+
+class TestExtractBashTarget:
+    def test_extracts_tests_script(self):
+        from modules.extractors import extract_bash_target
+
+        result = extract_bash_target(["bash", "tests/test_integration.sh"])
+        assert result == "tests/test_integration.sh"
+
+    def test_extracts_examples_script(self):
+        from modules.extractors import extract_bash_target
+
+        result = extract_bash_target(["bash", "examples/test_example.sh"])
+        assert result == "examples/test_example.sh"
+
+    def test_non_test_script_returns_none(self):
+        from modules.extractors import extract_bash_target
+
+        result = extract_bash_target(["bash", "scripts/setup.sh"])
+        assert result is None
+
+    def test_no_bash_returns_none(self):
+        from modules.extractors import extract_bash_target
+
+        result = extract_bash_target(["pytest", "tests/"])
+        assert result is None
+
+    def test_bash_with_flags(self):
+        from modules.extractors import extract_bash_target
+
+        result = extract_bash_target(["bash", "-e", "tests/test.sh"])
+        assert result == "tests/test.sh"
+
+
+# ============================================================================
+# should_keep_target
+# ============================================================================
+
+
+class TestShouldKeepTarget:
+    def test_keep_pytest_tests_directory(self):
+        from modules.extractors import should_keep_target
+
+        assert should_keep_target("tests", "pytest") is True
+        assert should_keep_target("tests/", "pytest") is True
+
+    def test_keep_specific_file(self):
+        from modules.extractors import should_keep_target
+
+        assert should_keep_target("tests/test_foo.py", "pytest") is True
+        assert should_keep_target("tests/test_foo.py", "bash") is True
+
+    def test_drop_tests_directory_for_non_pytest(self):
+        from modules.extractors import should_keep_target
+
+        assert should_keep_target("tests/", "bash") is False
+        assert should_keep_target("tests/", "torchrun") is False
+
+    def test_drop_tests_for_non_pytest(self):
+        from modules.extractors import should_keep_target
+
+        # "tests" (without trailing /) NOT in PYTEST_DIRECTORY_TARGETS
+        # and "tests" != "tests/", so second condition is True → keeps
+        assert should_keep_target("tests", "bash") is True
+        # "tests/" IS in PYTEST_DIRECTORY_TARGETS, so kept only for pytest
+        assert should_keep_target("tests/", "bash") is False
+
+
+# ============================================================================
+# is_ignored_pytest_target
+# ============================================================================
+
+
+class TestIsIgnoredPytestTarget:
+    def test_exact_path_match(self):
+        from modules.extractors import is_ignored_pytest_target
+
+        assert is_ignored_pytest_target("tests/skip.py", ["tests/skip.py"], []) is True
+
+    def test_prefix_match(self):
+        from modules.extractors import is_ignored_pytest_target
+
+        assert is_ignored_pytest_target("tests/skip/sub/test.py", ["tests/skip"], []) is True
+
+    def test_glob_match(self):
+        from modules.extractors import is_ignored_pytest_target
+
+        assert (
+            is_ignored_pytest_target("tests/deprecated/test_old.py", [], ["tests/*/deprecated/*"]) is False
+        )  # glob pattern doesn't match this path pattern
+        assert is_ignored_pytest_target("tests/deprecated/test_old.py", [], ["tests/deprecated/*"]) is True
+
+    def test_no_match(self):
+        from modules.extractors import is_ignored_pytest_target
+
+        assert is_ignored_pytest_target("tests/keep.py", [], []) is False
+
+    def test_normalized_paths(self):
+        from modules.extractors import is_ignored_pytest_target
+
+        assert is_ignored_pytest_target("tests\\skip.py", ["tests/skip.py"], []) is True
+
+
+# ============================================================================
+# extract_test_functions_from_text / module
+# ============================================================================
+
+
+class TestExtractTestFunctionsFromText:
+    def test_simple_test_function(self):
+        from modules.extractors import extract_test_functions_from_text
+
+        code = "def test_simple():\n    pass\n"
+        result = extract_test_functions_from_text(code)
+        assert "test_simple" in result
+
+    def test_test_class_with_methods(self):
+        from modules.extractors import extract_test_functions_from_text
+
+        code = """
+class TestMyFeature:
+    def test_method_one(self):
+        pass
+    def test_method_two(self):
+        pass
+"""
+        result = extract_test_functions_from_text(code)
+        assert "TestMyFeature::test_method_one" in result
+        assert "TestMyFeature::test_method_two" in result
+
+    def test_async_function(self):
+        from modules.extractors import extract_test_functions_from_text
+
+        code = "async def test_async():\n    pass\n"
+        result = extract_test_functions_from_text(code)
+        assert "test_async" in result
+
+    def test_non_test_functions_ignored(self):
+        from modules.extractors import extract_test_functions_from_text
+
+        code = "def helper():\n    pass\n"
+        result = extract_test_functions_from_text(code)
+        assert result == []
+
+    def test_non_test_class_ignored(self):
+        from modules.extractors import extract_test_functions_from_text
+
+        code = """
+class NotATest:
+    def test_method(self):
+        pass
+"""
+        result = extract_test_functions_from_text(code)
+        assert result == []
+
+    def test_syntax_error_returns_empty(self):
+        from modules.extractors import extract_test_functions_from_text
+
+        result = extract_test_functions_from_text("def broken(")
+        assert result == []
+
+    def test_mixed_scenario(self, sample_test_py_content):
+        from modules.extractors import extract_test_functions_from_text
+
+        result = extract_test_functions_from_text(sample_test_py_content)
+        assert "test_simple" in result
+        assert "test_with_fixture" in result
+        assert "test_async_function" in result
+        assert "TestMyFeature::test_method_one" in result
+        assert "TestMyFeature::test_method_two" in result
+        assert "TestMyFeature::test_async_method" in result
+        assert "TestAnotherFeature::test_another" in result
+        # Non-test functions/classes should be excluded
+        assert "helper_function" not in result
+        assert "NotATestClass::test_looks_like_test" not in result
+
+    def test_results_are_sorted_and_deduped(self):
+        from modules.extractors import extract_test_functions_from_text
+
+        code = """
+def test_b(): pass
+def test_a(): pass
+"""
+        result = extract_test_functions_from_text(code)
+        assert result == ["test_a", "test_b"]
+
+
+class TestExtractTestFunctionsFromModule:
+    def test_extracts_from_parsed_module(self):
+        from modules.extractors import extract_test_functions_from_module
+
+        module = ast.parse("def test_x():\n    pass\n")
+        result = extract_test_functions_from_module(module)
+        assert result == ["test_x"]
+
+    def test_extracts_class_methods(self):
+        from modules.extractors import extract_test_functions_from_module
+
+        code = """
+class TestX:
+    def test_a(self): pass
+    async def test_b(self): pass
+"""
+        module = ast.parse(code)
+        result = extract_test_functions_from_module(module)
+        assert result == ["TestX::test_a", "TestX::test_b"]
+
+
+# ============================================================================
+# extract_test_functions_from_file (I/O with tmp_path)
+# ============================================================================
+
+
+class TestExtractTestFunctionsFromFile:
+    def test_reads_file_and_extracts(self, sample_test_py_file):
+        from modules.extractors import extract_test_functions_from_file
+
+        result = extract_test_functions_from_file(sample_test_py_file)
+        assert "test_simple" in result
+
+    def test_nonexistent_file_raises(self, tmp_path):
+        from modules.extractors import extract_test_functions_from_file
+
+        with pytest.raises(FileNotFoundError):
+            extract_test_functions_from_file(tmp_path / "nonexistent.py")
+
+    def test_syntax_error_file_returns_empty(self, tmp_path):
+        from modules.extractors import extract_test_functions_from_file
+
+        bad_file = tmp_path / "bad_syntax.py"
+        bad_file.write_text("this is not valid python {{{", encoding="utf-8")
+        result = extract_test_functions_from_file(bad_file)
+        assert result == []
+
+    def test_file_without_test_functions(self, tmp_path):
+        from modules.extractors import extract_test_functions_from_file
+
+        helper_file = tmp_path / "helpers.py"
+        helper_file.write_text("def helper():\n    pass\n\nCONST = 42\n", encoding="utf-8")
+        result = extract_test_functions_from_file(helper_file)
+        assert result == []
+
+
+# ============================================================================
+# expand_python_test_file (I/O with tmp_path)
+# ============================================================================
+
+
+class TestExpandPythonTestFile:
+    def test_expands_to_function_level(self, sample_test_py_file, tmp_path):
+        # Copy to a known relative location
+        import shutil
+
+        from modules.extractors import expand_python_test_file
+
+        target = tmp_path / "tests" / "test_sample.py"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy(sample_test_py_file, target)
+
+        result = expand_python_test_file("tests/test_sample.py", tmp_path)
+        assert any("::" in r for r in result)
+
+    def test_nonexistent_file_falls_back(self, tmp_path):
+        from modules.extractors import expand_python_test_file
+
+        result = expand_python_test_file("tests/nonexistent.py", tmp_path)
+        assert result == ["tests/nonexistent.py"]
+
+    def test_file_without_test_functions_falls_back(self, tmp_path):
+        """Cover L176: file exists but has no test functions → returns [path_text]."""
+        from modules.extractors import expand_python_test_file
+
+        test_file = tmp_path / "tests" / "test_empty.py"
+        test_file.parent.mkdir(parents=True, exist_ok=True)
+        test_file.write_text("# no test functions here\nx = 1\n", encoding="utf-8")
+
+        result = expand_python_test_file("tests/test_empty.py", tmp_path)
+        assert result == ["tests/test_empty.py"]
+
+
+# ============================================================================
+# expand_pytest_targets
+# ============================================================================
+
+
+class TestExpandPytestTargets:
+    def test_directory_target(self, tmp_path):
+        from modules.extractors import expand_pytest_targets
+
+        # Create a tests directory with test files
+        tests_dir = tmp_path / "tests"
+        tests_dir.mkdir()
+        (tests_dir / "test_a.py").write_text("def test_one():\n    pass\n", encoding="utf-8")
+        (tests_dir / "test_b.py").write_text(
+            "class TestB:\n    def test_method(self):\n        pass\n",
+            encoding="utf-8",
+        )
+
+        result = expand_pytest_targets("tests", tmp_path, [], [])
+        # Should expand directory contents to function level
+        assert len(result) > 0
+        assert any("test_a.py" in r for r in result)
+
+    def test_python_file_target(self, tmp_path):
+        from modules.extractors import expand_pytest_targets
+
+        test_file = tmp_path / "tests" / "test_foo.py"
+        test_file.parent.mkdir(parents=True, exist_ok=True)
+        test_file.write_text("def test_bar():\n    pass\n", encoding="utf-8")
+
+        result = expand_pytest_targets("tests/test_foo.py", tmp_path, [], [])
+        assert "tests/test_foo.py::test_bar" in result
+
+    def test_non_py_non_dir_falls_back(self, tmp_path):
+        from modules.extractors import expand_pytest_targets
+
+        result = expand_pytest_targets("some/unknown/target", tmp_path, [], [])
+        assert result == ["some/unknown/target"]
+
+    def test_with_ignore_paths(self, tmp_path):
+        from modules.extractors import expand_pytest_targets
+
+        tests_dir = tmp_path / "tests"
+        tests_dir.mkdir()
+        (tests_dir / "test_keep.py").write_text("def test_keep():\n    pass\n", encoding="utf-8")
+        (tests_dir / "test_skip.py").write_text("def test_skip():\n    pass\n", encoding="utf-8")
+
+        result = expand_pytest_targets("tests", tmp_path, ["tests/test_skip.py"], [])
+        assert any("test_keep" in r for r in result)
+        assert not any("test_skip" in r for r in result)
+
+    def test_with_ignore_globs(self, tmp_path):
+        from modules.extractors import expand_pytest_targets
+
+        tests_dir = tmp_path / "tests"
+        sub_dir = tests_dir / "deprecated"
+        sub_dir.mkdir(parents=True)
+        (sub_dir / "test_old.py").write_text("def test_old():\n    pass\n", encoding="utf-8")
+
+        result = expand_pytest_targets("tests", tmp_path, [], ["tests/deprecated/*"])
+        assert not any("deprecated" in r for r in result)
+
+    def test_directory_rglob_skips_non_file(self, tmp_path):
+        """Cover L190: rglob returns a non-file entry → continue."""
+        from modules.extractors import expand_pytest_targets
+
+        tests_dir = tmp_path / "tests"
+        tests_dir.mkdir()
+        # Create a directory whose name matches test_*.py — rglob will find it
+        weird_dir = tests_dir / "test_not_a_file.py"
+        weird_dir.mkdir()
+        # Also create a real file so we get some results
+        (tests_dir / "test_real.py").write_text("def test_real():\n    pass\n", encoding="utf-8")
+
+        result = expand_pytest_targets("tests", tmp_path, [], [])
+        # Should only expand the real file, skipping the directory
+        assert any("test_real" in r for r in result)
+        assert not any("test_not_a_file" in r for r in result)

--- a/tests/ascend_ci_case_diff_scan/test_past_commits.py
+++ b/tests/ascend_ci_case_diff_scan/test_past_commits.py
@@ -1,0 +1,823 @@
+"""Tests for modules/past_commits.py."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from modules.past_commits import CommitInfo
+
+# ============================================================================
+# CommitInfo
+# ============================================================================
+
+
+class TestCommitInfo:
+    def test_construction(self):
+        ci = CommitInfo(
+            commit_hash="abc123",
+            commit_time="2026-05-30T00:00:00+00:00",
+            commit_title="Fix bug",
+            changed_files=("tests/test_foo.py", ".github/workflows/gpu.yml"),
+        )
+        assert ci.commit_hash == "abc123"
+        assert ci.commit_time == "2026-05-30T00:00:00+00:00"
+        assert ci.commit_title == "Fix bug"
+        assert ci.changed_files == ("tests/test_foo.py", ".github/workflows/gpu.yml")
+
+    def test_immutability(self):
+        from dataclasses import FrozenInstanceError
+
+        ci = CommitInfo(
+            commit_hash="abc123",
+            commit_time="",
+            commit_title="",
+            changed_files=(),
+        )
+        with pytest.raises(FrozenInstanceError):
+            ci.commit_hash = "new"  # type: ignore[misc]
+
+
+# ============================================================================
+# _normalize_commit_commit_hash
+# ============================================================================
+
+
+class TestNormalizeCommitHash:
+    def test_strips_whitespace(self):
+        from modules.past_commits import _normalize_commit_commit_hash
+
+        assert _normalize_commit_commit_hash("  abc123  ") == "abc123"
+        assert _normalize_commit_commit_hash("abc123\n") == "abc123"
+
+
+# ============================================================================
+# _is_relevant_path
+# ============================================================================
+
+
+class TestIsRelevantPath:
+    def test_workflow_path(self):
+        from modules.past_commits import _is_relevant_path
+
+        assert _is_relevant_path(".github/workflows/gpu_unit_tests.yml") is True
+
+    def test_test_path(self):
+        from modules.past_commits import _is_relevant_path
+
+        assert _is_relevant_path("tests/test_foo.py") is True
+        assert _is_relevant_path("tests/sub/test_bar.py") is True
+
+    def test_example_script(self):
+        from modules.past_commits import _is_relevant_path
+
+        assert _is_relevant_path("examples/test_example.sh") is True
+
+    def test_irrelevant_path(self):
+        from modules.past_commits import _is_relevant_path
+
+        assert _is_relevant_path("README.md") is False
+        assert _is_relevant_path("setup.py") is False
+        assert _is_relevant_path("examples/test_example.py") is False
+
+    def test_backslash_normalized(self):
+        from modules.past_commits import _is_relevant_path
+
+        assert _is_relevant_path(".github\\workflows\\test.yml") is True
+
+
+# ============================================================================
+# _case_change_key
+# ============================================================================
+
+
+class TestCaseChangeKey:
+    def test_produces_tuple(self):
+        from modules.past_commits import _case_change_key
+
+        case = {
+            "case_kind": "ut",
+            "command_type": "pytest",
+            "target": "tests/test_foo.py::test_add",
+            "signature": "pytest",
+            "workflow_name": "GPU Tests",
+            "job_name": "unit-tests",
+            "step_name": "Run pytest",
+            "raw_command": "pytest tests/",
+        }
+        result = _case_change_key(case)
+        assert isinstance(result, tuple)
+        assert result[0] == "ut"
+        assert result[1] == "pytest"
+        assert result[2] == "tests/test_foo.py::test_add"
+
+
+# ============================================================================
+# _path_or_child_changed
+# ============================================================================
+
+
+class TestPathOrChildChanged:
+    def test_exact_match(self):
+        from modules.past_commits import _path_or_child_changed
+
+        assert _path_or_child_changed("tests/test_foo.py", {"tests/test_foo.py"}) is True
+
+    def test_child_changed(self):
+        from modules.past_commits import _path_or_child_changed
+
+        assert _path_or_child_changed("tests/sub", {"tests/sub/test_bar.py"}) is True
+
+    def test_no_match(self):
+        from modules.past_commits import _path_or_child_changed
+
+        assert _path_or_child_changed("tests/module", {"tests/other/test.py"}) is False
+
+    def test_trailing_slash_normalized(self):
+        from modules.past_commits import _path_or_child_changed
+
+        assert _path_or_child_changed("tests/sub/", {"tests/sub/test.py"}) is True
+
+
+# ============================================================================
+# _workflow_status
+# ============================================================================
+
+
+class TestWorkflowStatus:
+    def test_added(self):
+        from modules.past_commits import _workflow_status
+
+        assert _workflow_status(None, object()) == "added"
+
+    def test_removed(self):
+        from modules.past_commits import _workflow_status
+
+        assert _workflow_status(object(), None) == "removed"
+
+    def test_modified(self):
+        from modules.past_commits import _workflow_status
+
+        assert _workflow_status(object(), object()) == "modified"
+
+
+# ============================================================================
+# _workflow_change_sort_key
+# ============================================================================
+
+
+class TestWorkflowChangeSortKey:
+    def test_added_before_modified(self):
+        from modules.past_commits import _workflow_change_sort_key
+
+        added_key = _workflow_change_sort_key({"workflow_status": "added", "workflow_path": "b.yml"})
+        modified_key = _workflow_change_sort_key({"workflow_status": "modified", "workflow_path": "a.yml"})
+        assert added_key < modified_key
+
+    def test_same_status_sorted_by_path(self):
+        from modules.past_commits import _workflow_change_sort_key
+
+        a_key = _workflow_change_sort_key({"workflow_status": "modified", "workflow_path": "a.yml"})
+        b_key = _workflow_change_sort_key({"workflow_status": "modified", "workflow_path": "b.yml"})
+        assert a_key < b_key
+
+
+# ============================================================================
+# _workflow_changed
+# ============================================================================
+
+
+class TestWorkflowChanged:
+    def test_added(self):
+        from modules.past_commits import _workflow_changed
+
+        head_info = object()
+        assert _workflow_changed(None, head_info, set(), []) is True
+
+    def test_removed(self):
+        from modules.past_commits import _workflow_changed
+
+        base_info = object()
+        assert _workflow_changed(base_info, None, set(), []) is True
+
+    def test_no_change(self):
+        from modules.config import WorkflowInfo
+        from modules.past_commits import _workflow_changed
+
+        base = WorkflowInfo("A", "a.yml", "a.yml", "gpu", "a")
+        head = WorkflowInfo("A", "a.yml", "a.yml", "gpu", "a")
+
+        # Same info + same case keys = no change
+        base_keys = {("ut", "pytest", "t", "s", "w", "j", "s", "c")}
+        head_cases = [
+            {
+                "case_kind": "ut",
+                "command_type": "pytest",
+                "target": "t",
+                "signature": "s",
+                "workflow_name": "w",
+                "job_name": "j",
+                "step_name": "s",
+                "raw_command": "c",
+            }
+        ]
+
+        assert _workflow_changed(base, head, base_keys, head_cases) is False
+
+    def test_name_changed(self):
+        from modules.config import WorkflowInfo
+        from modules.past_commits import _workflow_changed
+
+        base = WorkflowInfo("A", "a.yml", "a.yml", "gpu", "a")
+        head = WorkflowInfo("B", "a.yml", "a.yml", "gpu", "a")
+
+        assert _workflow_changed(base, head, set(), []) is True
+
+    def test_kind_changed(self):
+        from modules.config import WorkflowInfo
+        from modules.past_commits import _workflow_changed
+
+        base = WorkflowInfo("A", "a.yml", "a.yml", "gpu", "a")
+        head = WorkflowInfo("A", "a.yml", "a.yml", "cpu", "a")
+
+        assert _workflow_changed(base, head, set(), []) is True
+
+
+# ============================================================================
+# _case_target_changed
+# ============================================================================
+
+
+class TestCaseTargetChanged:
+    def test_workflow_path_changed(self):
+        from modules.past_commits import _case_target_changed
+
+        case = {
+            "workflow_path": ".github/workflows/gpu_unit_tests.yml",
+            "command_type": "pytest",
+            "target": "tests/test_foo.py::test_add",
+        }
+        changed = {".github/workflows/gpu_unit_tests.yml"}
+        assert _case_target_changed(case, changed) is True
+
+    def test_pytest_target_changed(self):
+        from modules.past_commits import _case_target_changed
+
+        case = {
+            "workflow_path": ".github/workflows/gpu_unit_tests.yml",
+            "command_type": "pytest",
+            "target": "tests/test_foo.py::test_add",
+        }
+        changed = {"tests/test_foo.py"}
+        assert _case_target_changed(case, changed) is True
+
+    def test_bash_target_changed(self):
+        from modules.past_commits import _case_target_changed
+
+        case = {
+            "workflow_path": ".github/workflows/gpu.yml",
+            "command_type": "bash",
+            "target": "tests/test_integration.sh",
+        }
+        changed = {"tests/test_integration.sh"}
+        assert _case_target_changed(case, changed) is True
+
+    def test_torchrun_target_changed(self):
+        from modules.past_commits import _case_target_changed
+
+        case = {
+            "workflow_path": ".github/workflows/gpu_e2e.yml",
+            "command_type": "torchrun",
+            "target": "tests/test_trainer.py",
+        }
+        changed = {"tests/test_trainer.py"}
+        assert _case_target_changed(case, changed) is True
+
+    def test_no_change(self):
+        from modules.past_commits import _case_target_changed
+
+        case = {
+            "workflow_path": ".github/workflows/gpu_unit_tests.yml",
+            "command_type": "pytest",
+            "target": "tests/test_foo.py::test_add",
+        }
+        changed = {"tests/test_other.py"}
+        assert _case_target_changed(case, changed) is False
+
+
+# ============================================================================
+# _commit_touches_case_path
+# ============================================================================
+
+
+class TestCommitTouchesCasePath:
+    def test_workflow_touched(self):
+        from modules.past_commits import _commit_touches_case_path
+
+        commit = CommitInfo("a", "", "", (".github/workflows/gpu.yml",))
+        case = {
+            "workflow_path": ".github/workflows/gpu.yml",
+            "command_type": "pytest",
+            "target": "tests/test_foo.py::test_add",
+        }
+        assert _commit_touches_case_path(commit, case) is True
+
+    def test_pytest_file_touched(self):
+        from modules.past_commits import _commit_touches_case_path
+
+        commit = CommitInfo("a", "", "", ("tests/test_foo.py",))
+        case = {
+            "workflow_path": ".github/workflows/gpu.yml",
+            "command_type": "pytest",
+            "target": "tests/test_foo.py::test_add",
+        }
+        assert _commit_touches_case_path(commit, case) is True
+
+    def test_bash_file_touched(self):
+        from modules.past_commits import _commit_touches_case_path
+
+        commit = CommitInfo("a", "", "", ("tests/run.sh",))
+        case = {
+            "workflow_path": ".github/workflows/gpu.yml",
+            "command_type": "bash",
+            "target": "tests/run.sh",
+        }
+        assert _commit_touches_case_path(commit, case) is True
+
+    def test_no_touch(self):
+        from modules.past_commits import _commit_touches_case_path
+
+        commit = CommitInfo("a", "", "", ("README.md",))
+        case = {
+            "workflow_path": ".github/workflows/gpu.yml",
+            "command_type": "pytest",
+            "target": "tests/test_foo.py::test_add",
+        }
+        assert _commit_touches_case_path(commit, case) is False
+
+
+# ============================================================================
+# _collect_window_changed_files
+# ============================================================================
+
+
+class TestCollectWindowChangedFiles:
+    def test_collects_and_dedupes(self):
+        from modules.past_commits import _collect_window_changed_files
+
+        commits = [
+            CommitInfo("a", "", "", ("tests/test_a.py", "tests/test_b.py")),
+            CommitInfo("b", "", "", ("tests/test_a.py", "tests/test_c.py")),
+        ]
+        result = _collect_window_changed_files(commits)
+        assert result == {"tests/test_a.py", "tests/test_b.py", "tests/test_c.py"}
+
+
+# ============================================================================
+# _summarize_details
+# ============================================================================
+
+
+class TestSummarizeDetails:
+    def test_aligned_cases_excluded(self):
+        from modules.past_commits import _summarize_details
+
+        details = [
+            {
+                "workflow_path": "gpu.yml",
+                "npu_status": "aligned",
+                "case_kind": "ut",
+                "case_id": "u1",
+            }
+        ]
+        result = _summarize_details(details)
+        assert result == []
+
+    def test_counts_gaps(self):
+        from modules.past_commits import _summarize_details
+
+        details = [
+            {
+                "workflow_path": "gpu.yml",
+                "npu_status": "missing_in_npu_workflows",
+                "case_kind": "ut",
+                "case_id": "u1",
+            },
+            {
+                "workflow_path": "gpu.yml",
+                "npu_status": "missing_in_npu_workflows",
+                "case_kind": "ut",
+                "case_id": "u2",
+            },
+            {
+                "workflow_path": "gpu.yml",
+                "npu_status": "missing_in_npu_workflows",
+                "case_kind": "st",
+                "case_id": "s1",
+            },
+        ]
+        result = _summarize_details(details)
+        assert len(result) == 1  # one row for this workflow+status pair
+        assert result[0]["ut_gap_count"] == 2
+        assert result[0]["st_gap_count"] == 1
+
+    def test_dedup_case_ids(self):
+        from modules.past_commits import _summarize_details
+
+        details = [
+            {
+                "workflow_path": "gpu.yml",
+                "npu_status": "missing_in_npu_workflows",
+                "case_kind": "ut",
+                "case_id": "u1",
+            },
+            {
+                "workflow_path": "gpu.yml",
+                "npu_status": "missing_in_npu_workflows",
+                "case_kind": "ut",
+                "case_id": "u1",  # duplicate
+            },
+        ]
+        result = _summarize_details(details)
+        # Should dedupe by case_id, so only 1 UT gap
+        assert result[0]["ut_gap_count"] == 1
+
+
+# ============================================================================
+# _status_rank
+# ============================================================================
+
+
+class TestStatusRank:
+    def test_ordering(self):
+        from modules.past_commits import _status_rank
+
+        assert _status_rank("aligned") < _status_rank("manual_review_needed")
+        assert _status_rank("manual_review_needed") < _status_rank("missing_in_npu_workflows")
+        assert _status_rank("missing_in_npu_workflows") < _status_rank("npu_only")
+
+    def test_unknown_status(self):
+        from modules.past_commits import _status_rank
+
+        assert _status_rank("unknown") == 99
+
+
+# ============================================================================
+# _collect_changed_head_cases
+# ============================================================================
+
+
+class TestCollectChangedHeadCases:
+    def test_new_case_not_in_base(self):
+        from modules.past_commits import _collect_changed_head_cases
+
+        head_cases = [
+            {
+                "workflow_kind": "gpu",
+                "case_id": "new_case",
+                "case_kind": "ut",
+                "command_type": "pytest",
+                "target": "tests/test_new.py::test_feature",
+                "signature": "pytest",
+                "workflow_name": "GPU Tests",
+                "job_name": "j",
+                "step_name": "s",
+                "raw_command": "pytest tests/",
+                "workflow_path": ".github/workflows/gpu.yml",
+            }
+        ]
+        base_keys = set()  # empty base
+        changed_files = set()
+
+        result = _collect_changed_head_cases(head_cases, base_keys, changed_files)
+        assert len(result) == 1
+        assert result[0]["case_id"] == "new_case"
+
+    def test_npu_case_excluded(self):
+        from modules.past_commits import _collect_changed_head_cases
+
+        head_cases = [
+            {
+                "workflow_kind": "npu",
+                "case_id": "npu_case",
+                "case_kind": "ut",
+                "command_type": "pytest",
+                "target": "tests/test_npu.py::test_feature",
+                "signature": "pytest",
+                "workflow_name": "NPU Tests",
+                "job_name": "j",
+                "step_name": "s",
+                "raw_command": "pytest tests/",
+                "workflow_path": ".github/workflows/npu.yml",
+            }
+        ]
+        base_keys = set()
+        changed_files = set()
+
+        result = _collect_changed_head_cases(head_cases, base_keys, changed_files)
+        assert result == []
+
+    def test_dedup_by_case_id(self):
+        from modules.past_commits import _collect_changed_head_cases
+
+        head_cases = [
+            {
+                "workflow_kind": "gpu",
+                "case_id": "dup_case",
+                "case_kind": "ut",
+                "command_type": "pytest",
+                "target": "tests/test_a.py::test_1",
+                "signature": "pytest",
+                "workflow_name": "GPU Tests",
+                "job_name": "j1",
+                "step_name": "s1",
+                "raw_command": "pytest tests/",
+                "workflow_path": ".github/workflows/gpu.yml",
+            },
+            {
+                "workflow_kind": "gpu",
+                "case_id": "dup_case",  # same case_id
+                "case_kind": "ut",
+                "command_type": "pytest",
+                "target": "tests/test_a.py::test_1",
+                "signature": "pytest",
+                "workflow_name": "GPU Tests",
+                "job_name": "j2",
+                "step_name": "s2",
+                "raw_command": "pytest tests/",
+                "workflow_path": ".github/workflows/gpu.yml",
+            },
+        ]
+        base_keys = set()
+        changed_files = set()
+
+        result = _collect_changed_head_cases(head_cases, base_keys, changed_files)
+        assert len(result) == 1
+
+
+# ============================================================================
+# case_details_for_workflow
+# ============================================================================
+
+
+class TestCaseDetailsForWorkflow:
+    def test_filters_by_workflow_path(self):
+        from modules.past_commits import case_details_for_workflow
+
+        details = [
+            {"workflow_path": "a.yml", "case_name": "case_a"},
+            {"workflow_path": "b.yml", "case_name": "case_b"},
+            {"workflow_path": "a.yml", "case_name": "case_c"},
+        ]
+        result = case_details_for_workflow(details, "a.yml")
+        assert len(result) == 2
+        assert all(r["workflow_path"] == "a.yml" for r in result)
+
+
+# ============================================================================
+# _run_git and related (mocked subprocess)
+# ============================================================================
+
+
+class TestRunGit:
+    def test_successful_call(self):
+        from modules.past_commits import _run_git
+
+        with patch("modules.past_commits.subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="abc123\ndef456\n", stderr=""
+            )
+            result = _run_git(Path("/fake/repo"), "log")
+            assert result == "abc123\ndef456\n"
+            mock_run.assert_called_once()
+
+    def test_called_process_error_propagates(self):
+        from modules.past_commits import _run_git
+
+        with patch("modules.past_commits.subprocess.run") as mock_run:
+            mock_run.side_effect = subprocess.CalledProcessError(
+                returncode=128, cmd=["git"], stderr="fatal: not a git repository"
+            )
+            with pytest.raises(subprocess.CalledProcessError):
+                _run_git(Path("/fake/repo"), "log")
+
+
+class TestGetFirstParentCommits:
+    def test_parses_hash_list(self):
+        from modules.past_commits import _get_first_parent_commits
+
+        with patch("modules.past_commits._run_git") as mock_git:
+            mock_git.return_value = "abc123\ndef456\n\n"
+            result = _get_first_parent_commits(Path("/fake/repo"), 7)
+            assert result == ["abc123", "def456"]
+
+    def test_empty_output(self):
+        from modules.past_commits import _get_first_parent_commits
+
+        with patch("modules.past_commits._run_git") as mock_git:
+            mock_git.return_value = ""
+            result = _get_first_parent_commits(Path("/fake/repo"), 7)
+            assert result == []
+
+
+class TestGetCommitInfo:
+    def test_parses_commit_data(self):
+        from modules.past_commits import _get_commit_info
+
+        with patch("modules.past_commits._run_git") as mock_git:
+            # First call: show command
+            # Second call: diff-tree
+            mock_git.side_effect = [
+                "abc123\x1f2026-05-30T00:00:00+00:00\x1fFix bug",
+                "tests/test_foo.py\n.github/workflows/gpu.yml\nREADME.md\n",
+            ]
+            result = _get_commit_info(Path("/fake/repo"), "abc123")
+            assert result.commit_hash == "abc123"
+            assert result.commit_title == "Fix bug"
+            # README.md should be excluded (not relevant)
+            assert "tests/test_foo.py" in result.changed_files
+            assert ".github/workflows/gpu.yml" in result.changed_files
+            assert "README.md" not in result.changed_files
+
+
+class TestGetBaseCommit:
+    def test_returns_parent_commit(self):
+        from modules.past_commits import _get_base_commit
+
+        with patch("modules.past_commits._run_git") as mock_git:
+            mock_git.return_value = "parent_hash\n"
+            result = _get_base_commit(Path("/fake/repo"), "abc123")
+            assert result == "parent_hash"
+
+    def test_returns_none_on_error(self):
+        from modules.past_commits import _get_base_commit
+
+        with patch("modules.past_commits._run_git") as mock_git:
+            mock_git.side_effect = subprocess.CalledProcessError(128, ["git"], "")
+            result = _get_base_commit(Path("/fake/repo"), "abc123")
+            assert result is None
+
+
+# ============================================================================
+# _build_head_status_index / _lookup_npu_support
+# ============================================================================
+
+
+class TestHeadStatusIndex:
+    def test_indexes_aligned_cases(self):
+        from modules.past_commits import _build_head_status_index
+
+        # Build minimal head cases that should match
+        # This is a simplified integration test of the indexing logic
+        head_cases = []
+        # With no cases, index should be empty
+        index = _build_head_status_index(head_cases)
+        assert "ut" in index
+        assert "st" in index
+        assert index["ut"] == {}
+        assert index["st"] == {}
+
+
+class TestLookupNpuSupport:
+    def test_not_found_returns_missing(self):
+        from modules.past_commits import _lookup_npu_support
+
+        case = {
+            "case_kind": "ut",
+            "pair_key": "test",
+            "command_type": "pytest",
+            "target": "tests/test_foo.py::test_add",
+            "signature": "pytest",
+        }
+        status_index = {"ut": {}, "st": {}}
+        status, refs = _lookup_npu_support(case, status_index)
+        assert status == "missing_in_npu_workflows"
+        assert refs == []
+
+
+# ============================================================================
+# _build_commit_details
+# ============================================================================
+
+
+class TestBuildCommitDetails:
+    def test_excludes_commits_without_affected_workflows(self):
+        from modules.past_commits import _build_commit_details
+
+        commits = [
+            CommitInfo("a", "2026-01-01T00:00:00", "Commit A", ("tests/test_a.py",)),
+            CommitInfo("b", "2026-01-02T00:00:00", "Commit B", ("README.md",)),
+        ]
+        workflow_changes = [{"commit_hashes": ("a",), "workflow_path": "gpu.yml"}]
+        case_details = []
+
+        result = _build_commit_details(commits, workflow_changes, case_details)
+        # Only commit A should appear since it affects a workflow
+        assert len(result) == 1
+        assert result[0]["commit_hash"] == "a"
+
+    def test_dedups_affected_workflows(self):
+        from modules.past_commits import _build_commit_details
+
+        commits = [
+            CommitInfo("a", "2026-01-01T00:00:00", "Commit A", ("tests/test_a.py",)),
+            CommitInfo("b", "2026-01-02T00:00:00", "Commit B", ("tests/test_b.py",)),
+        ]
+        # Both commits affect the same workflow
+        workflow_changes = [
+            {"commit_hashes": ("a", "b"), "workflow_path": "gpu.yml"},
+        ]
+        case_details = []
+
+        result = _build_commit_details(commits, workflow_changes, case_details)
+        assert len(result) == 2
+
+
+# ============================================================================
+# build_past_commit_report (integration with mocks)
+# ============================================================================
+
+
+class TestBuildPastCommitReport:
+    def test_empty_commits_returns_empty_report(self, empty_config):
+        from modules.past_commits import build_past_commit_report
+
+        with patch("modules.past_commits._get_commit_sequence") as mock_seq:
+            mock_seq.return_value = []
+            result = build_past_commit_report(Path("/fake/repo"), empty_config, 7, [])
+
+            assert result["commit_count"] == 0
+            assert result["summary"] == []
+            assert result["workflow_changes"] == []
+            assert result["case_details"] == []
+            assert result["commit_details"] == []
+
+    def test_with_commits_and_changes(self, empty_config):
+        from modules.past_commits import build_past_commit_report
+
+        commits = [
+            CommitInfo(
+                "abc123",
+                "2026-05-30T00:00:00",
+                "Add test",
+                (".github/workflows/gpu_unit_tests.yml", "tests/test_new.py"),
+            ),
+        ]
+
+        with (
+            patch("modules.past_commits._get_commit_sequence") as mock_seq,
+            patch("modules.past_commits._get_base_commit") as mock_base,
+            patch("modules.past_commits._run_git") as mock_git,
+            patch("modules.past_commits._materialize_snapshot") as _mock_materialize,
+            patch("modules.past_commits._load_snapshot_scan") as mock_load,
+        ):
+            mock_seq.return_value = commits
+            mock_base.return_value = "base_hash"
+            mock_git.return_value = "head_hash"
+
+            # Mock snapshot scans: base has 1 case, head has 2 (1 new)
+            from modules.config import WorkflowInfo
+
+            base_info = WorkflowInfo("GPU Tests", "gpu.yml", "gpu.yml", "gpu", "gpu")
+            head_info = WorkflowInfo("GPU Tests", "gpu.yml", "gpu.yml", "gpu", "gpu")
+
+            base_grouped = {"gpu": {"cpu_gpu": [base_info], "npu": []}}
+            head_grouped = {"gpu": {"cpu_gpu": [head_info], "npu": []}}
+
+            def make_case(case_id, target, workflow_path="gpu.yml"):
+                return {
+                    "workflow_name": "GPU Tests",
+                    "workflow_path": workflow_path,
+                    "file_name": "gpu.yml",
+                    "workflow_kind": "gpu",
+                    "pair_key": "gpu",
+                    "job_name": "unit-tests",
+                    "step_name": "Run pytest",
+                    "line_number": 10,
+                    "command_type": "pytest",
+                    "case_kind": "ut",
+                    "target": target,
+                    "raw_command": "pytest tests/",
+                    "signature": "pytest",
+                    "case_id": case_id,
+                    "display_name": target,
+                }
+
+            base_cases = [make_case("c1", "tests/test_old.py::test_old")]
+            head_cases = [
+                make_case("c1", "tests/test_old.py::test_old"),
+                make_case("c2", "tests/test_new.py::test_new"),
+            ]
+
+            # Mock _load_snapshot_scan for base and head
+            mock_load.side_effect = [
+                (base_grouped, base_cases, {"gpu.yml": base_cases}, {"gpu.yml": base_info}),
+                (head_grouped, head_cases, {"gpu.yml": head_cases}, {"gpu.yml": head_info}),
+            ]
+
+            result = build_past_commit_report(Path("/fake/repo"), empty_config, 7, head_cases)
+
+            assert result["commit_count"] == 1
+            assert "abc123" in result["commit_details"][0]["commit_hash"]

--- a/tests/ascend_ci_case_diff_scan/test_workflows.py
+++ b/tests/ascend_ci_case_diff_scan/test_workflows.py
@@ -1,0 +1,786 @@
+"""Tests for modules/workflows.py."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# ============================================================================
+# classify_workflow
+# ============================================================================
+
+
+class TestClassifyWorkflow:
+    def test_cpu_unit_tests(self):
+        from modules.workflows import classify_workflow
+
+        assert classify_workflow("cpu_unit_tests", "") == "cpu"
+
+    def test_ascend_suffix(self):
+        from modules.workflows import classify_workflow
+
+        assert classify_workflow("gpu_unit_tests_ascend", "") == "npu"
+        assert classify_workflow("e2e_ascend", "") == "npu"
+
+    def test_nightly_ascend(self):
+        from modules.workflows import classify_workflow
+
+        assert classify_workflow("nightly_ascend", "") == "npu"
+
+    def test_npu_unit_tests(self):
+        from modules.workflows import classify_workflow
+
+        assert classify_workflow("npu_unit_tests", "") == "npu"
+
+    def test_runs_on_aarch64(self):
+        from modules.workflows import classify_workflow
+
+        content = "jobs:\n  test:\n    runs-on: aarch64"
+        assert classify_workflow("some_workflow", content) == "npu"
+
+    def test_runs_on_a2(self):
+        from modules.workflows import classify_workflow
+
+        content = "jobs:\n  test:\n    runs-on: a2-highgpu-8g"
+        assert classify_workflow("some_workflow", content) == "npu"
+
+    def test_image_ascend(self):
+        from modules.workflows import classify_workflow
+
+        content = "jobs:\n  test:\n    container:\n      image: ascend-mindspore"
+        assert classify_workflow("some_workflow", content) == "npu"
+
+    def test_default_gpu(self):
+        from modules.workflows import classify_workflow
+
+        assert classify_workflow("gpu_unit_tests", "") == "gpu"
+        assert classify_workflow("e2e_ppo_trainer", "") == "gpu"
+
+    def test_case_insensitive(self):
+        from modules.workflows import classify_workflow
+
+        assert classify_workflow("MY_ASCEND", "") == "npu"
+        assert classify_workflow("CPU_UNIT_TESTS", "") == "cpu"
+
+
+# ============================================================================
+# workflow_pair_key
+# ============================================================================
+
+
+class TestWorkflowPairKey:
+    def test_npu_unit_tests_maps_to_gpu(self):
+        from modules.workflows import workflow_pair_key
+
+        assert workflow_pair_key("npu_unit_tests") == "gpu_unit_tests"
+
+    def test_ascend_suffix_stripped(self):
+        from modules.workflows import workflow_pair_key
+
+        assert workflow_pair_key("foo_ascend") == "foo"
+
+    def test_no_special_mapping(self):
+        from modules.workflows import workflow_pair_key
+
+        assert workflow_pair_key("bar") == "bar"
+
+    def test_case_insensitive(self):
+        from modules.workflows import workflow_pair_key
+
+        assert workflow_pair_key("FOO_ASCEND") == "foo"
+
+
+# ============================================================================
+# tokenize_command
+# ============================================================================
+
+
+class TestTokenizeCommand:
+    def test_simple_command(self):
+        from modules.workflows import tokenize_command
+
+        result = tokenize_command("pytest tests/")
+        assert result == ["pytest", "tests/"]
+
+    def test_with_quotes(self):
+        from modules.workflows import tokenize_command
+
+        result = tokenize_command('pytest -k "test_foo or test_bar" tests/')
+        assert "pytest" in result
+        assert "-k" in result
+        assert "test_foo or test_bar" in result
+        assert "tests/" in result
+
+    def test_with_single_quotes(self):
+        from modules.workflows import tokenize_command
+
+        result = tokenize_command("pytest -k 'test_foo' tests/")
+        assert "test_foo" in result
+
+    def test_comments_removed(self):
+        from modules.workflows import tokenize_command
+
+        result = tokenize_command("pytest tests/  # run all tests")
+        assert "#" not in result
+        assert "run" not in result
+
+    def test_fallback_to_split(self):
+        from modules.workflows import tokenize_command
+
+        # A command with unmatched quotes triggers ValueError -> fallback to split
+        result = tokenize_command('pytest -k "unclosed tests/')
+        # Should not crash, should return something
+        assert len(result) > 0
+        assert "pytest" in result
+
+
+# ============================================================================
+# split_shell_commands
+# ============================================================================
+
+
+class TestSplitShellCommands:
+    def test_single_command(self):
+        from modules.workflows import split_shell_commands
+
+        result = split_shell_commands("pytest tests/")
+        assert result == ["pytest tests/"]
+
+    def test_double_ampersand(self):
+        from modules.workflows import split_shell_commands
+
+        result = split_shell_commands("cd tests && pytest tests/")
+        assert len(result) == 2
+        assert "cd tests" in result
+        assert "pytest tests/" in result
+
+    def test_double_pipe(self):
+        from modules.workflows import split_shell_commands
+
+        result = split_shell_commands("pytest tests/ || echo failed")
+        assert len(result) == 2
+
+    def test_semicolon(self):
+        from modules.workflows import split_shell_commands
+
+        result = split_shell_commands("export FOO=bar; pytest tests/")
+        assert len(result) == 2
+
+    def test_quoted_separator_not_split(self):
+        from modules.workflows import split_shell_commands
+
+        # && inside quotes should not cause a split
+        result = split_shell_commands('echo "hello && world"')
+        assert len(result) == 1
+        assert "&&" in result[0]
+
+    def test_empty_result_filtered(self):
+        from modules.workflows import split_shell_commands
+
+        result = split_shell_commands("")
+        assert result == [""] or result == []
+
+    def test_single_quote_prevents_split(self):
+        """Cover L124: single-quoted content with && is not split."""
+        from modules.workflows import split_shell_commands
+
+        result = split_shell_commands("echo 'hello && world'")
+        assert len(result) == 1
+        assert "&&" in result[0]
+
+
+# ============================================================================
+# command_uses_pytest / command_uses_torchrun
+# ============================================================================
+
+
+class TestCommandDetection:
+    def test_uses_pytest_true(self):
+        from modules.workflows import command_uses_pytest
+
+        assert command_uses_pytest(["pytest", "tests/"]) is True
+
+    def test_uses_pytest_false(self):
+        from modules.workflows import command_uses_pytest
+
+        assert command_uses_pytest(["torchrun", "tests/test.py"]) is False
+
+    def test_uses_torchrun_in_tokens(self):
+        from modules.workflows import command_uses_torchrun
+
+        assert command_uses_torchrun("", ["torchrun", "tests/test.py"]) is True
+
+    def test_uses_torchrun_in_command(self):
+        from modules.workflows import command_uses_torchrun
+
+        assert command_uses_torchrun("torchrun tests/test.py", ["python"]) is True
+
+    def test_uses_torchrun_not_present(self):
+        from modules.workflows import command_uses_torchrun
+
+        assert command_uses_torchrun("pytest tests/", ["pytest"]) is False
+
+
+# ============================================================================
+# normalize_signature
+# ============================================================================
+
+
+class TestNormalizeSignature:
+    def test_pytest_signature_strips_ignore(self):
+        from modules.workflows import normalize_signature
+
+        result = normalize_signature("pytest tests/ --ignore tests/skip.py", "tests/")
+        assert "--ignore" not in result
+        assert "tests/skip.py" not in result
+
+    def test_pytest_signature_strips_selection(self):
+        from modules.workflows import normalize_signature
+
+        result = normalize_signature("pytest -k 'test_foo' tests/", "tests/")
+        assert "-k" not in result
+        assert "test_foo" not in result
+
+    def test_pytest_signature_keeps_env_vars(self):
+        from modules.workflows import normalize_signature
+
+        result = normalize_signature("FOO=bar pytest tests/", "tests/")
+        assert "FOO=bar" in result
+
+    def test_pytest_signature_sorts_env_vars(self):
+        from modules.workflows import normalize_signature
+
+        result = normalize_signature("Z=2 A=1 pytest tests/", "tests/")
+        # Env vars should be sorted: A=1 before Z=2
+        a_pos = result.index("A=1")
+        z_pos = result.index("Z=2")
+        assert a_pos < z_pos
+
+    def test_non_pytest_signature_normalizes_paths(self):
+        from modules.workflows import normalize_signature
+
+        result = normalize_signature("torchrun tests\\test.py", "tests/test.py")
+        assert "\\" not in result
+
+    def test_empty_tokens(self):
+        from modules.workflows import normalize_signature
+
+        # This would be an edge case with empty tokenize
+        result = normalize_signature("", "")
+        assert result == ""
+
+    def test_pytest_with_inline_ignore_removed(self):
+        from modules.workflows import normalize_signature
+
+        result = normalize_signature("pytest --ignore=tests/skip.py tests/", "tests/")
+        assert "skip.py" not in result
+
+    def test_pytest_signature_keeps_regular_flags(self):
+        """Cover L106-108: non-ignore, non-selection flags kept in signature."""
+        from modules.workflows import normalize_signature
+
+        result = normalize_signature("pytest -x -v tests/", "tests/")
+        assert "-x" in result
+        assert "-v" in result
+
+    def test_pytest_signature_inline_k_equals(self):
+        """Cover L103-104: inline -k=expr form skipped."""
+        from modules.workflows import normalize_signature
+
+        result = normalize_signature("pytest -k=slow tests/", "tests/")
+        assert "slow" not in result
+
+
+# ============================================================================
+# _merge_shell_continuations
+# ============================================================================
+
+
+class TestMergeShellContinuations:
+    def test_single_line(self):
+        from modules.workflows import _merge_shell_continuations
+
+        entries = [("pytest tests/", 1)]
+        result = _merge_shell_continuations(entries)
+        assert len(result) == 1
+        assert result[0][0] == "pytest tests/"
+        assert result[0][1] == 1
+
+    def test_backslash_continuation(self):
+        from modules.workflows import _merge_shell_continuations
+
+        entries = [
+            ("pytest \\", 1),
+            ("tests/", 2),
+        ]
+        result = _merge_shell_continuations(entries)
+        assert len(result) == 1
+        assert result[0][0] == "pytest tests/"
+        assert result[0][1] == 1
+
+    def test_empty_entries(self):
+        from modules.workflows import _merge_shell_continuations
+
+        result = _merge_shell_continuations([])
+        assert result == []
+
+    def test_empty_first_line_skipped(self):
+        from modules.workflows import _merge_shell_continuations
+
+        entries = [
+            ("", 1),
+            ("pytest tests/", 2),
+        ]
+        result = _merge_shell_continuations(entries)
+        assert len(result) == 1
+        assert result[0][0] == "pytest tests/"
+
+    def test_trailing_continuation(self):
+        """Cover L229-231: dangling continuation at end of entries."""
+        from modules.workflows import _merge_shell_continuations
+
+        entries = [
+            ("pytest \\", 1),
+            ("tests/ \\", 2),
+        ]
+        result = _merge_shell_continuations(entries)
+        assert len(result) == 1
+        assert "pytest" in result[0][0]
+        assert "tests/" in result[0][0]
+
+
+# ============================================================================
+# _ends_with_shell_continuation
+# ============================================================================
+
+
+class TestEndsWithShellContinuation:
+    def test_odd_backslashes(self):
+        from modules.workflows import _ends_with_shell_continuation
+
+        assert _ends_with_shell_continuation("pytest \\") is True
+
+    def test_even_backslashes(self):
+        from modules.workflows import _ends_with_shell_continuation
+
+        assert _ends_with_shell_continuation("pytest \\\\") is False
+
+    def test_no_backslash(self):
+        from modules.workflows import _ends_with_shell_continuation
+
+        assert _ends_with_shell_continuation("pytest tests/") is False
+
+
+# ============================================================================
+# build_case_id / build_display_name
+# ============================================================================
+
+
+class TestBuildCaseId:
+    def test_produces_pipe_separated_id(self):
+        from modules.workflows import build_case_id
+
+        case = {
+            "case_kind": "ut",
+            "command_type": "pytest",
+            "target": "tests/test_foo.py::test_add",
+            "signature": "pytest",
+            "workflow_name": "GPU Tests",
+            "job_name": "unit-tests",
+            "step_name": "Run pytest",
+            "line_number": 10,
+        }
+        result = build_case_id(case)
+        assert "ut|" in result
+        assert "pytest|" in result
+        assert "tests/test_foo.py::test_add" in result
+        assert str(10) in result
+
+
+class TestBuildDisplayName:
+    def test_ut_case_shows_target(self):
+        from modules.workflows import build_display_name
+
+        case = {
+            "case_kind": "ut",
+            "target": "tests/test_foo.py::test_add",
+            "workflow_name": "GPU Tests",
+            "job_name": "unit-tests",
+            "step_name": "Run pytest",
+        }
+        result = build_display_name(case)
+        assert result == "tests/test_foo.py::test_add"
+
+    def test_st_case_shows_context(self):
+        from modules.workflows import build_display_name
+
+        case = {
+            "case_kind": "st",
+            "target": "tests/test_integration.sh",
+            "workflow_name": "GPU Tests",
+            "job_name": "e2e-tests",
+            "step_name": "Run bash test",
+        }
+        result = build_display_name(case)
+        assert "tests/test_integration.sh" in result
+        assert "GPU Tests" in result
+        assert "e2e-tests" in result
+        assert "Run bash test" in result
+
+
+# ============================================================================
+# build_workflow_groups
+# ============================================================================
+
+
+class TestBuildWorkflowGroups:
+    def test_groups_by_pair_key(self):
+        from modules.config import WorkflowInfo
+        from modules.workflows import build_workflow_groups
+
+        cpu_info = WorkflowInfo("A", "a.yml", "a.yml", "gpu", "pair_a")
+        npu_info = WorkflowInfo("A Ascend", "a_ascend.yml", "a_ascend.yml", "npu", "pair_a")
+
+        result = build_workflow_groups([cpu_info, npu_info])
+
+        assert "pair_a" in result
+        assert len(result["pair_a"]["cpu_gpu"]) == 1
+        assert len(result["pair_a"]["npu"]) == 1
+
+    def test_standalone_npu(self):
+        from modules.config import WorkflowInfo
+        from modules.workflows import build_workflow_groups
+
+        npu_only = WorkflowInfo("E2E Ascend", "e2e_ascend.yml", "e2e_ascend.yml", "npu", "e2e")
+
+        result = build_workflow_groups([npu_only])
+
+        assert "e2e" in result
+        assert len(result["e2e"]["cpu_gpu"]) == 0
+        assert len(result["e2e"]["npu"]) == 1
+
+    def test_standalone_cpu_gpu(self):
+        from modules.config import WorkflowInfo
+        from modules.workflows import build_workflow_groups
+
+        gpu_only = WorkflowInfo("GPU Tests", "gpu_unit_tests.yml", "gpu_unit_tests.yml", "gpu", "gpu_unit_tests")
+
+        result = build_workflow_groups([gpu_only])
+
+        assert "gpu_unit_tests" in result
+        assert len(result["gpu_unit_tests"]["cpu_gpu"]) == 1
+        assert len(result["gpu_unit_tests"]["npu"]) == 0
+
+
+# ============================================================================
+# parse_workflow_content (pure - takes strings)
+# ============================================================================
+
+
+class TestParseWorkflowContent:
+    def test_extracts_pytest_case(self, sample_workflow_yaml, empty_config, tmp_path):
+        from modules.workflows import parse_workflow_content
+
+        info, cases = parse_workflow_content(
+            "gpu_unit_tests.yml",
+            ".github/workflows/gpu_unit_tests.yml",
+            sample_workflow_yaml,
+            tmp_path,
+            empty_config,
+        )
+
+        assert info is not None
+        assert info.workflow_kind == "gpu"
+        assert info.workflow_name in ("GPU Unit Tests", "gpu_unit_tests")
+        assert len(cases) > 0
+        assert any(c["command_type"] == "pytest" for c in cases)
+
+    def test_extracts_torchrun_case(self, sample_torchrun_workflow_yaml, empty_config, tmp_path):
+        from modules.workflows import parse_workflow_content
+
+        info, cases = parse_workflow_content(
+            "gpu_e2e.yml",
+            ".github/workflows/gpu_e2e.yml",
+            sample_torchrun_workflow_yaml,
+            tmp_path,
+            empty_config,
+        )
+
+        assert info is not None
+        assert any(c["command_type"] == "torchrun" for c in cases)
+
+    def test_extracts_bash_case(self, sample_bash_workflow_yaml, empty_config, tmp_path):
+        from modules.workflows import parse_workflow_content
+
+        info, cases = parse_workflow_content(
+            "bash_test.yml",
+            ".github/workflows/bash_test.yml",
+            sample_bash_workflow_yaml,
+            tmp_path,
+            empty_config,
+        )
+
+        assert info is not None
+        assert any(c["command_type"] == "bash" for c in cases)
+
+    def test_non_ignored_workflow_returns_info(self, empty_config, tmp_path):
+        from modules.workflows import parse_workflow_content
+
+        info, cases = parse_workflow_content(
+            "docker-build.yml",
+            ".github/workflows/docker-build.yml",
+            "name: Docker\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - run: docker build .",
+            tmp_path,
+            empty_config,
+        )
+
+        # docker-build.yml is NOT in empty_config's ignored list, so info is not None
+        assert info is not None
+
+    def test_actually_ignored_workflow(self, sample_config, tmp_path):
+        from modules.workflows import parse_workflow_content
+
+        info, cases = parse_workflow_content(
+            "doc.yml",
+            ".github/workflows/doc.yml",
+            "name: Docs",
+            tmp_path,
+            sample_config,
+        )
+
+        assert info is None
+        assert cases == []
+
+    def test_multi_step_workflow(self, sample_multi_step_workflow_yaml, empty_config, tmp_path):
+        from modules.workflows import parse_workflow_content
+
+        info, cases = parse_workflow_content(
+            "multi.yml",
+            ".github/workflows/multi.yml",
+            sample_multi_step_workflow_yaml,
+            tmp_path,
+            empty_config,
+        )
+
+        assert info is not None
+        # Should have cases from multiple jobs
+        job_names = {c["job_name"] for c in cases}
+        assert "first-job" in job_names
+        assert "second-job" in job_names
+
+    def test_cases_have_required_fields(self, sample_workflow_yaml, empty_config, tmp_path):
+        from modules.workflows import parse_workflow_content
+
+        _, cases = parse_workflow_content(
+            "gpu_unit_tests.yml",
+            ".github/workflows/gpu_unit_tests.yml",
+            sample_workflow_yaml,
+            tmp_path,
+            empty_config,
+        )
+
+        for case in cases:
+            for field in [
+                "workflow_name",
+                "workflow_path",
+                "file_name",
+                "workflow_kind",
+                "pair_key",
+                "job_name",
+                "step_name",
+                "line_number",
+                "command_type",
+                "case_kind",
+                "target",
+                "raw_command",
+                "signature",
+                "case_id",
+                "display_name",
+            ]:
+                assert field in case, f"Missing field '{field}' in case {case.get('case_id', '?')}"
+
+    def test_ascend_workflow_classified_as_npu(self, sample_ascend_workflow_yaml, empty_config, tmp_path):
+        from modules.workflows import parse_workflow_content
+
+        info, _ = parse_workflow_content(
+            "npu_unit_tests.yml",
+            ".github/workflows/npu_unit_tests.yml",
+            sample_ascend_workflow_yaml,
+            tmp_path,
+            empty_config,
+        )
+
+        assert info is not None
+        assert info.workflow_kind == "npu"
+
+
+# ============================================================================
+# _extract_cases_from_command edge branches
+# ============================================================================
+
+
+class TestExtractCasesFromCommand:
+    def test_empty_command_returns_empty(self, tmp_path):
+        """Cover L284: empty command → []."""
+        from modules.workflows import _extract_cases_from_command
+
+        result = _extract_cases_from_command("", tmp_path)
+        assert result == []
+
+    def test_comment_command_returns_empty(self, tmp_path):
+        """Cover L288: comment command → []."""
+        from modules.workflows import _extract_cases_from_command
+
+        result = _extract_cases_from_command("# pytest tests/", tmp_path)
+        assert result == []
+
+    def test_pytest_file_target_shape(self, tmp_path):
+        """Cover L310-311: target_shape = 'pytest-file' when target ends with .py."""
+        from modules.workflows import _extract_cases_from_command
+
+        # Create the target file so expand_pytest_targets can parse it
+        test_file = tmp_path / "tests" / "test_foo.py"
+        test_file.parent.mkdir(parents=True, exist_ok=True)
+        test_file.write_text("def test_one():\n    pass\n", encoding="utf-8")
+
+        result = _extract_cases_from_command("pytest tests/test_foo.py", tmp_path)
+        assert len(result) > 0
+        assert any("pytest-file" in c["signature"] for c in result)
+
+    def test_dedup_identical_cases(self, tmp_path):
+        """Cover L331: duplicate cases with same key are deduped."""
+        from modules.workflows import _extract_cases_from_command
+
+        # Two identical bash commands in same step would produce same extraction
+        # For dedup test: extract twice and verify the function produces at most 1
+        result = _extract_cases_from_command("bash tests/test_integration.sh", tmp_path)
+        # The dedup is within a single command extraction, so this mainly
+        # exercises the dedup code path (even if no duplicates found)
+        assert isinstance(result, list)
+
+
+# ============================================================================
+# collect_scan_data: workflow content returns None
+# ============================================================================
+
+
+class TestCollectScanDataEdgeCases:
+    def test_workflow_content_parse_returns_none(self, tmp_path, empty_config):
+        """Cover L419-420: parse_workflow returns None for non-ignored workflow."""
+        from modules.workflows import collect_scan_data
+
+        wf_dir = tmp_path / ".github" / "workflows"
+        wf_dir.mkdir(parents=True)
+        # Create a file that exists but whose content triggers ignore
+        # by having no valid jobs with run commands
+        (wf_dir / "empty.yml").write_text("name: Empty\n", encoding="utf-8")
+
+        workflow_infos, cases, ignored_paths = collect_scan_data(tmp_path, empty_config)
+
+        # empty.yml has no ignored pattern, but parse_workflow_content may still
+        # process it. If it returns None, it goes to ignored_paths (L419-420).
+        # Either way, the code path is exercised.
+        assert isinstance(ignored_paths, list)
+
+
+# ============================================================================
+# multiline run: entries with empty lines and indented continuations
+# ============================================================================
+
+
+class TestMultilineRunEntries:
+    def test_empty_line_in_multiline_run(self):
+        """Cover L185-186: empty next_line skipped in _extract_run_entries."""
+        from modules.workflows import _extract_run_entries
+
+        lines = [
+            "        run: |",
+            "",
+            "          pytest tests/",
+        ]
+        entries, next_idx = _extract_run_entries(lines, 0, 8, "|")
+        assert len(entries) == 1
+        assert "pytest" in entries[0][0]
+
+    def test_indented_continuation_line(self):
+        """Cover L189-191: continuation line with indent-based extraction."""
+        from modules.workflows import _extract_run_entries
+
+        lines = [
+            "        run: |",
+            "          pytest tests/",
+            "          pytest tests/more/",
+        ]
+        entries, next_idx = _extract_run_entries(lines, 0, 8, "|")
+        assert len(entries) == 2
+
+
+# ============================================================================
+# parse_workflow (I/O with tmp_path)
+# ============================================================================
+
+
+class TestParseWorkflow:
+    def test_parses_yaml_file(self, tmp_path, empty_config, sample_workflow_yaml):
+        from modules.workflows import parse_workflow
+
+        wf_dir = tmp_path / ".github" / "workflows"
+        wf_dir.mkdir(parents=True)
+        wf_file = wf_dir / "gpu_unit_tests.yml"
+        wf_file.write_text(sample_workflow_yaml, encoding="utf-8")
+
+        info, cases = parse_workflow(wf_file, tmp_path, empty_config)
+
+        assert info is not None
+        assert len(cases) > 0
+
+
+# ============================================================================
+# collect_scan_data (I/O with tmp_path)
+# ============================================================================
+
+
+class TestCollectScanData:
+    def test_collects_from_workflow_directory(self, tmp_path, empty_config, sample_workflow_yaml):
+        from modules.workflows import collect_scan_data
+
+        wf_dir = tmp_path / ".github" / "workflows"
+        wf_dir.mkdir(parents=True)
+        (wf_dir / "gpu_unit_tests.yml").write_text(sample_workflow_yaml, encoding="utf-8")
+
+        workflow_infos, cases, ignored_paths = collect_scan_data(tmp_path, empty_config)
+
+        assert len(workflow_infos) == 1
+        assert len(cases) > 0
+        assert ignored_paths == []
+
+    def test_ignores_matching_workflows(self, tmp_path, sample_config, sample_workflow_yaml):
+        from modules.workflows import collect_scan_data
+
+        wf_dir = tmp_path / ".github" / "workflows"
+        wf_dir.mkdir(parents=True)
+        (wf_dir / "gpu_unit_tests.yml").write_text(sample_workflow_yaml, encoding="utf-8")
+        (wf_dir / "doc.yml").write_text("name: Docs", encoding="utf-8")
+
+        workflow_infos, cases, ignored_paths = collect_scan_data(tmp_path, sample_config)
+
+        # doc.yml should be ignored, gpu_unit_tests.yml should be scanned
+        assert len(workflow_infos) == 1
+        assert "doc.yml" in [Path(p).name for p in ignored_paths]
+
+    def test_both_yaml_extensions(self, tmp_path, empty_config):
+        from modules.workflows import collect_scan_data
+
+        wf_dir = tmp_path / ".github" / "workflows"
+        wf_dir.mkdir(parents=True)
+        (wf_dir / "test.yml").write_text(
+            "name: Test\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: pytest tests/",
+            encoding="utf-8",
+        )
+        (wf_dir / "other.yaml").write_text(
+            "name: Other\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: pytest tests/",
+            encoding="utf-8",
+        )
+
+        workflow_infos, cases, _ = collect_scan_data(tmp_path, empty_config)
+
+        assert len(workflow_infos) == 2

--- a/tests/ascend_ci_case_diff_scan/test_workflows.py
+++ b/tests/ascend_ci_case_diff_scan/test_workflows.py
@@ -647,15 +647,16 @@ class TestExtractCasesFromCommand:
         assert any("pytest-file" in c["signature"] for c in result)
 
     def test_dedup_identical_cases(self, tmp_path):
-        """Cover L331: duplicate cases with same key are deduped."""
+        """Cover L326-334: dedup safety net exercised."""
         from modules.workflows import _extract_cases_from_command
 
-        # Two identical bash commands in same step would produce same extraction
-        # For dedup test: extract twice and verify the function produces at most 1
+        # Within a single command, bash/torchrun/pytest are mutually exclusive,
+        # so dedup is rarely triggered — it exists as a safety net.
+        # Verify the result has expected shape and content fields.
         result = _extract_cases_from_command("bash tests/test_integration.sh", tmp_path)
-        # The dedup is within a single command extraction, so this mainly
-        # exercises the dedup code path (even if no duplicates found)
-        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0]["command_type"] == "bash"
+        assert result[0]["target"] == "tests/test_integration.sh"
 
 
 # ============================================================================
@@ -664,22 +665,19 @@ class TestExtractCasesFromCommand:
 
 
 class TestCollectScanDataEdgeCases:
-    def test_workflow_content_parse_returns_none(self, tmp_path, empty_config):
-        """Cover L419-420: parse_workflow returns None for non-ignored workflow."""
+    def test_workflow_without_run_steps_parsed_with_zero_cases(self, tmp_path, empty_config):
+        """Workflow without jobs/run steps is parsed with 0 cases, not ignored."""
         from modules.workflows import collect_scan_data
 
         wf_dir = tmp_path / ".github" / "workflows"
         wf_dir.mkdir(parents=True)
-        # Create a file that exists but whose content triggers ignore
-        # by having no valid jobs with run commands
         (wf_dir / "empty.yml").write_text("name: Empty\n", encoding="utf-8")
 
         workflow_infos, cases, ignored_paths = collect_scan_data(tmp_path, empty_config)
 
-        # empty.yml has no ignored pattern, but parse_workflow_content may still
-        # process it. If it returns None, it goes to ignored_paths (L419-420).
-        # Either way, the code path is exercised.
-        assert isinstance(ignored_paths, list)
+        # Not ignored (no matching pattern in empty_config), parsed with 0 cases
+        assert any(info.file_name == "empty.yml" for info in workflow_infos)
+        assert len(ignored_paths) == 0
 
 
 # ============================================================================
@@ -699,7 +697,7 @@ class TestMultilineRunEntries:
         ]
         entries, next_idx = _extract_run_entries(lines, 0, 8, "|")
         assert len(entries) == 1
-        assert "pytest" in entries[0][0]
+        assert entries[0][0] == "pytest tests/"
 
     def test_indented_continuation_line(self):
         """Cover L189-191: continuation line with indent-based extraction."""
@@ -712,6 +710,8 @@ class TestMultilineRunEntries:
         ]
         entries, next_idx = _extract_run_entries(lines, 0, 8, "|")
         assert len(entries) == 2
+        assert entries[0][0] == "pytest tests/"
+        assert entries[1][0] == "pytest tests/more/"
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

Add comprehensive unit tests for three core modules of the `ascend-ci-case-diff-scan` skill — **186 test cases**, all passing.

## Coverage 

| Source Module | Stmts | Coverage | Test File | Cases |
|---------------|-------|----------|-----------|-------|
| `extractors.py` | 130 | **100%**  | `test_extractors.py` | 59 |
| `workflows.py` | 276 | **97%** | `test_workflows.py` | 72 |
| `past_commits.py` | 258 | **86%** | `test_past_commits.py` | 55 |
| **Total** | **664** | **94%**  | | **186** |

- `extractors.py` — **100%** line coverage. Every path exercised: command target extraction, pytest spec expansion, AST function extraction, path filtering, and ignore logic.
- `workflows.py` — **97%** coverage. The 7 uncovered statements are YAML parse degradation paths that only trigger on malformed input.
- `past_commits.py` — **86%** coverage. The 36 uncovered statements are git subprocess edge cases (network failure, empty repository) that require integration-level setup.

## Test Architecture

- **pytest + stdlib only** — no extra test dependencies. `unittest.mock` used solely for git subprocess and ZipFile I/O stubs; `ast`, `shlex`, `re`, and `fnmatch` are all exercised with real inputs.
- **Filesystem isolation** — every I/O test uses `tmp_path`, zero cross-test contamination.
- **One class per function** — each source function maps to a dedicated `Test*` class with self-describing method names.
