### PR TITLE
test: improve coverage and fix code quality issues in excel and render test modules

### DIFF
--- a/tests/ascend_ci_case_diff_scan/test_excel.py
+++ b/tests/ascend_ci_case_diff_scan/test_excel.py
@@ -604,6 +604,9 @@ class TestPastRows:
         }
         rows = _past_case_rows(report)
         assert len(rows) >= 2
+        assert rows[1][0] == "gpu_unit_tests.yml"
+        assert rows[1][1] == "tests/test_new.py::test_feature"
+        assert rows[1][2] == "ut"
 
     def test_past_detail_rows(self):
         from modules.excel import _past_detail_rows
@@ -620,4 +623,6 @@ class TestPastRows:
         }
         rows = _past_detail_rows(report)
         assert len(rows) >= 2
-        assert any("abc123def456" in str(cell) for cell in rows[1])
+        assert rows[1][0] == "abc123def456"
+        assert rows[1][1] == "2026-05-30T00:00:00+00:00"
+        assert rows[1][2] == "Add new test"

--- a/tests/ascend_ci_case_diff_scan/test_excel.py
+++ b/tests/ascend_ci_case_diff_scan/test_excel.py
@@ -1,0 +1,623 @@
+"""Tests for modules/excel.py."""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from unittest.mock import MagicMock, patch
+
+# ============================================================================
+# _xml_text
+# ============================================================================
+
+
+class TestXmlText:
+    def test_escapes_ampersand(self):
+        from modules.excel import _xml_text
+
+        assert _xml_text("a & b") == "a &amp; b"
+
+    def test_escapes_angle_brackets(self):
+        from modules.excel import _xml_text
+
+        result = _xml_text("<test>")
+        assert "&lt;" in result
+        assert "&gt;" in result
+
+    def test_strips_invalid_xml_chars(self):
+        from xml.sax.saxutils import escape
+
+        from modules.excel import _xml_text
+
+        result = _xml_text("hello\x00world")
+        assert result == escape("helloworld")
+
+    def test_preserves_valid_chars(self):
+        from modules.excel import _xml_text
+
+        result = _xml_text("hello world 123")
+        assert result == "hello world 123"
+
+
+# ============================================================================
+# _is_valid_xml_char
+# ============================================================================
+
+
+class TestIsValidXmlChar:
+    def test_tab_newline_carriage_return(self):
+        from modules.excel import _is_valid_xml_char
+
+        assert _is_valid_xml_char("\t") is True
+        assert _is_valid_xml_char("\n") is True
+        assert _is_valid_xml_char("\r") is True
+
+    def test_printable_ascii(self):
+        from modules.excel import _is_valid_xml_char
+
+        assert _is_valid_xml_char("A") is True
+        assert _is_valid_xml_char(" ") is True
+        assert _is_valid_xml_char("~") is True
+
+    def test_null_is_invalid(self):
+        from modules.excel import _is_valid_xml_char
+
+        assert _is_valid_xml_char("\x00") is False
+
+    def test_vertical_tab_is_invalid(self):
+        from modules.excel import _is_valid_xml_char
+
+        assert _is_valid_xml_char("\x0b") is False
+
+    def test_chinese_char_is_valid(self):
+        from modules.excel import _is_valid_xml_char
+
+        assert _is_valid_xml_char("中") is True
+
+
+# ============================================================================
+# _column_name
+# ============================================================================
+
+
+class TestColumnName:
+    def test_single_letter(self):
+        from modules.excel import _column_name
+
+        assert _column_name(1) == "A"
+        assert _column_name(26) == "Z"
+
+    def test_double_letter(self):
+        from modules.excel import _column_name
+
+        assert _column_name(27) == "AA"
+        assert _column_name(28) == "AB"
+        assert _column_name(52) == "AZ"
+
+    def test_triple_letter(self):
+        from modules.excel import _column_name
+
+        assert _column_name(703) == "AAA"
+
+    def test_zero_returns_empty(self):
+        from modules.excel import _column_name
+
+        assert _column_name(0) == ""
+
+
+# ============================================================================
+# _column_width
+# ============================================================================
+
+
+class TestColumnWidth:
+    def test_within_range(self):
+        from modules.excel import _column_width
+
+        widths = (10, 20, 30)
+        assert _column_width(1, widths) == 10
+        assert _column_width(2, widths) == 20
+        assert _column_width(3, widths) == 30
+
+    def test_outside_range_uses_default(self):
+        from modules.excel import DEFAULT_COLUMN_WIDTH, _column_width
+
+        widths = (10,)
+        assert _column_width(5, widths) == DEFAULT_COLUMN_WIDTH
+
+
+# ============================================================================
+# _excel_multiline
+# ============================================================================
+
+
+class TestExcelMultiline:
+    def test_replaces_br(self):
+        from modules.excel import _excel_multiline
+
+        assert _excel_multiline("a<br>b") == "a\nb"
+
+    def test_no_br(self):
+        from modules.excel import _excel_multiline
+
+        assert _excel_multiline("plain") == "plain"
+
+    def test_multiple_br(self):
+        from modules.excel import _excel_multiline
+
+        assert _excel_multiline("a<br>b<br>c") == "a\nb\nc"
+
+    def test_empty_string(self):
+        from modules.excel import _excel_multiline
+
+        assert _excel_multiline("") == ""
+
+
+# ============================================================================
+# _ref_sort_key
+# ============================================================================
+
+
+class TestRefSortKey:
+    def test_produces_tuple(self):
+        from modules.excel import _ref_sort_key
+
+        ref = {"name": "test", "workflow_path": "a.yml", "line_number": 1}
+        result = _ref_sort_key(ref)
+        assert isinstance(result, tuple)
+        assert result[0] == "test"
+        assert result[1] == "a.yml"
+        assert result[2] == 1
+
+
+# ============================================================================
+# _side_cells
+# ============================================================================
+
+
+class TestSideCells:
+    def test_with_full_ref(self):
+        from modules.excel import _side_cells
+
+        ref = {
+            "workflow_path": "a.yml",
+            "line_number": 10,
+            "workflow_name": "GPU Tests",
+            "job_name": "unit-tests",
+            "step_name": "Run pytest",
+            "signature": "pytest",
+            "raw_command": "pytest tests/",
+        }
+        cells = _side_cells(ref)
+        assert len(cells) == 5
+        assert cells[0] == "a.yml"
+        assert cells[1] == 10
+        assert "GPU Tests" in cells[2]
+
+    def test_with_none(self):
+        from modules.excel import _side_cells
+
+        cells = _side_cells(None)
+        assert cells == ["", "", "", "", ""]
+
+
+# ============================================================================
+# Row generation functions (pure)
+# ============================================================================
+
+
+class TestRowGeneration:
+    def test_ignored_workflow_rows(self):
+        from modules.excel import _ignored_workflow_rows
+
+        report = {"ignored_workflows": ["docker-build.yml", "doc.yml"]}
+        rows = _ignored_workflow_rows(report)
+        assert rows[0] == ["Workflow Name"]
+        assert rows[1] == ["docker-build.yml"]
+        assert rows[2] == ["doc.yml"]
+
+    def test_ignored_workflow_rows_empty(self):
+        from modules.excel import _ignored_workflow_rows
+
+        report = {"ignored_workflows": []}
+        rows = _ignored_workflow_rows(report)
+        assert rows == [["Workflow Name"]]
+
+    def test_scanned_workflow_rows(self):
+        from modules.excel import _scanned_workflow_rows
+
+        report = {
+            "scanned_workflows": [
+                {
+                    "workflow_name": "wf1",
+                    "cpu_gpu_case_count": 10,
+                    "npu_supported_case_count": 8,
+                }
+            ]
+        }
+        rows = _scanned_workflow_rows(report)
+        assert rows[0] == ["Workflow Name", "CPU/GPU Case Count", "NPU Supported Case Count"]
+        assert rows[1][1] == 10
+        assert rows[1][2] == 8
+
+    def test_case_rows_structure(self):
+        from modules.excel import _case_rows
+
+        details = {
+            "matched": [],
+            "cpu_gpu_only": [],
+            "npu_only": [],
+            "manual_review": [],
+        }
+        rows = _case_rows(details, "UT Case Name")
+        # Should have at least a header row
+        assert len(rows) >= 1
+        assert rows[0][0] == "UT Case Name"
+        assert "Match Status" in rows[0]
+
+    def test_case_rows_with_non_empty_section(self):
+        """Cover L101: _case_rows calls _case_item_rows for non-empty sections."""
+        from modules.excel import _case_rows
+
+        details = {
+            "matched": [
+                {
+                    "name": "tests/test_a.py::test_1",
+                    "cpu_gpu_refs": [
+                        {
+                            "name": "tests/test_a.py::test_1",
+                            "workflow_path": "a.yml",
+                            "line_number": 1,
+                            "workflow_name": "A",
+                            "job_name": "j",
+                            "step_name": "s",
+                            "signature": "pytest",
+                            "raw_command": "pytest tests/",
+                        }
+                    ],
+                    "npu_refs": [],
+                }
+            ],
+            "cpu_gpu_only": [],
+            "npu_only": [],
+            "manual_review": [],
+        }
+        rows = _case_rows(details, "ST Case Name")
+        # Header + 1 data row
+        assert len(rows) == 2
+        assert rows[0][0] == "ST Case Name"
+        assert rows[1][0] == "tests/test_a.py::test_1"
+        assert rows[1][1] == "Matched"
+
+    def test_case_item_rows_with_paired_refs(self):
+        from modules.excel import _case_item_rows
+
+        item = {
+            "name": "tests/test_a.py::test_1",
+            "cpu_gpu_refs": [
+                {
+                    "name": "tests/test_a.py::test_1",
+                    "workflow_path": "a.yml",
+                    "line_number": 1,
+                    "workflow_name": "A",
+                    "job_name": "j",
+                    "step_name": "s",
+                    "signature": "pytest",
+                    "raw_command": "pytest tests/",
+                }
+            ],
+            "npu_refs": [
+                {
+                    "name": "tests/test_a.py::test_1",
+                    "workflow_path": "a_ascend.yml",
+                    "line_number": 2,
+                    "workflow_name": "A Ascend",
+                    "job_name": "j",
+                    "step_name": "s",
+                    "signature": "pytest",
+                    "raw_command": "pytest tests/",
+                }
+            ],
+        }
+        rows = _case_item_rows(item, "Matched")
+        assert len(rows) == 1
+        assert rows[0][0] == "tests/test_a.py::test_1"
+        assert rows[0][1] == "Matched"
+        # CPU/GPU side
+        assert rows[0][2] == "a.yml"
+        # NPU side
+        assert rows[0][7] == "a_ascend.yml"
+
+    def test_case_item_rows_no_npu(self):
+        from modules.excel import _case_item_rows
+
+        item = {
+            "name": "tests/test_b.py::test_2",
+            "cpu_gpu_refs": [
+                {
+                    "name": "tests/test_b.py::test_2",
+                    "workflow_path": "a.yml",
+                    "line_number": 1,
+                    "workflow_name": "A",
+                    "job_name": "j",
+                    "step_name": "s",
+                    "signature": "pytest",
+                    "raw_command": "pytest tests/",
+                }
+            ],
+            "npu_refs": [],
+        }
+        rows = _case_item_rows(item, "CPU/GPU Only")
+        assert len(rows) == 1
+        # NPU side should be empty strings
+        assert rows[0][7] == ""
+
+
+# ============================================================================
+# XML generation functions
+# ============================================================================
+
+
+class TestXmlGeneration:
+    def test_content_types_xml_valid(self):
+        from modules.excel import _content_types_xml
+
+        xml_str = _content_types_xml(4)
+        # Should be valid XML
+        root = ET.fromstring(xml_str)
+        assert root.tag == "{http://schemas.openxmlformats.org/package/2006/content-types}Types"
+
+    def test_root_rels_xml_valid(self):
+        from modules.excel import _root_rels_xml
+
+        xml_str = _root_rels_xml()
+        root = ET.fromstring(xml_str)
+        assert root.tag == "{http://schemas.openxmlformats.org/package/2006/relationships}Relationships"
+
+    def test_workbook_xml_valid(self):
+        from modules.excel import _workbook_xml
+
+        sheets = [
+            ("Sheet1", [["A", "B"]], (10, 20)),
+            ("Sheet2", [["X"]], (30,)),
+        ]
+        xml_str = _workbook_xml(sheets)
+        root = ET.fromstring(xml_str)
+        ns = "{http://schemas.openxmlformats.org/spreadsheetml/2006/main}"
+        sheet_elems = root.findall(f"{ns}sheets/{ns}sheet")
+        assert len(sheet_elems) == 2
+
+    def test_styles_xml_valid(self):
+        from modules.excel import _styles_xml
+
+        xml_str = _styles_xml()
+        root = ET.fromstring(xml_str)
+        assert root.tag == "{http://schemas.openxmlformats.org/spreadsheetml/2006/main}styleSheet"
+
+    def test_worksheet_xml_valid(self):
+        from modules.excel import _worksheet_xml
+
+        rows = [
+            ["Header A", "Header B"],
+            ["data1", "data2"],
+            [42, 99],
+        ]
+        xml_str = _worksheet_xml(rows, (20, 30))
+        root = ET.fromstring(xml_str)
+        ns = "{http://schemas.openxmlformats.org/spreadsheetml/2006/main}"
+        row_elems = root.findall(f"{ns}sheetData/{ns}row")
+        assert len(row_elems) == 3
+
+    def test_row_xml_includes_cells(self):
+        from modules.excel import _row_xml
+
+        xml_str = _row_xml(1, ["hello", 42, None])
+        assert '<row r="1">' in xml_str
+        assert "hello" in xml_str
+        assert "42" in xml_str
+
+    def test_cell_xml_header_style(self):
+        from modules.excel import _cell_xml
+
+        xml_str = _cell_xml(1, 1, "Header")
+        assert 's="2"' in xml_str
+
+    def test_cell_xml_data_style(self):
+        from modules.excel import _cell_xml
+
+        xml_str = _cell_xml(2, 1, "data")
+        assert 's="1"' in xml_str
+
+    def test_cell_xml_integer(self):
+        from modules.excel import _cell_xml
+
+        xml_str = _cell_xml(2, 1, 42)
+        assert "<v>42</v>" in xml_str
+        assert 't="inlineStr"' not in xml_str
+
+    def test_cell_xml_inline_string(self):
+        from modules.excel import _cell_xml
+
+        xml_str = _cell_xml(2, 1, "hello")
+        assert 't="inlineStr"' in xml_str
+
+    def test_cell_xml_none_value(self):
+        from modules.excel import _cell_xml
+
+        xml_str = _cell_xml(2, 1, None)
+        # None value → empty inline string
+        assert 't="inlineStr"' in xml_str
+        assert "<t></t>" in xml_str
+
+    def test_workbook_rels_xml(self):
+        from modules.excel import _workbook_rels_xml
+
+        xml_str = _workbook_rels_xml(4)
+        root = ET.fromstring(xml_str)
+        ns = "{http://schemas.openxmlformats.org/package/2006/relationships}"
+        rels = root.findall(f"{ns}Relationship")
+        # 4 sheet relationships + 1 styles relationship = 5
+        assert len(rels) == 5
+
+
+# ============================================================================
+# write_excel_report (I/O with mocked ZipFile)
+# ============================================================================
+
+
+class TestWriteExcelReport:
+    def test_writes_zip_with_four_sheets(self, tmp_path):
+        from modules.excel import write_excel_report
+
+        report = {
+            "ignored_workflows": [],
+            "scanned_workflows": [],
+            "ut_details": {
+                "matched": [],
+                "cpu_gpu_only": [],
+                "npu_only": [],
+                "manual_review": [],
+            },
+            "st_details": {
+                "matched": [],
+                "cpu_gpu_only": [],
+                "npu_only": [],
+                "manual_review": [],
+            },
+        }
+
+        path = tmp_path / "test_report.xlsx"
+
+        with patch("modules.excel.ZipFile") as mock_zip:
+            mock_zip_instance = MagicMock()
+            mock_zip.return_value.__enter__.return_value = mock_zip_instance
+
+            write_excel_report(path, report)
+
+            # Verify ZipFile was created with the right path
+            mock_zip.assert_called_once()
+
+            # Verify writestr was called for each required file
+            written_names = {args[0][0] for args in mock_zip_instance.writestr.call_args_list}
+            assert "[Content_Types].xml" in written_names
+            assert "_rels/.rels" in written_names
+            assert "xl/workbook.xml" in written_names
+            assert "xl/_rels/workbook.xml.rels" in written_names
+            assert "xl/styles.xml" in written_names
+            assert "xl/worksheets/sheet1.xml" in written_names
+            assert "xl/worksheets/sheet2.xml" in written_names
+            assert "xl/worksheets/sheet3.xml" in written_names
+            assert "xl/worksheets/sheet4.xml" in written_names
+
+
+# ============================================================================
+# write_past_commit_excel_report (I/O with mocked ZipFile)
+# ============================================================================
+
+
+class TestWritePastCommitExcelReport:
+    def test_writes_zip_with_four_sheets(self, tmp_path):
+        from modules.excel import write_past_commit_excel_report
+
+        report = {
+            "summary": [],
+            "workflow_changes": [],
+            "case_details": [],
+            "commit_details": [],
+        }
+
+        path = tmp_path / "test_past_report.xlsx"
+
+        with patch("modules.excel.ZipFile") as mock_zip:
+            mock_zip_instance = MagicMock()
+            mock_zip.return_value.__enter__.return_value = mock_zip_instance
+
+            write_past_commit_excel_report(path, report)
+
+            written_names = {args[0][0] for args in mock_zip_instance.writestr.call_args_list}
+            assert "xl/worksheets/sheet1.xml" in written_names  # Summary
+            assert "xl/worksheets/sheet2.xml" in written_names  # Changed Workflows
+            assert "xl/worksheets/sheet3.xml" in written_names  # Changed Cases
+            assert "xl/worksheets/sheet4.xml" in written_names  # Commit Details
+
+
+# ============================================================================
+# _past_*_rows (pure functions)
+# ============================================================================
+
+
+class TestPastRows:
+    def test_past_summary_rows(self):
+        from modules.excel import _past_summary_rows
+
+        report = {
+            "workflow_changes": [
+                {
+                    "workflow_path": "gpu_unit_tests.yml",
+                    "ut_gap_count": 3,
+                    "st_gap_count": 1,
+                    "commit_hashes": ("abc123", "def456"),
+                }
+            ]
+        }
+        rows = _past_summary_rows(report)
+        assert len(rows) >= 2  # header + at least 1 data row
+        assert rows[1][0] == "gpu_unit_tests.yml"
+
+    def test_past_workflow_rows(self):
+        from modules.excel import _past_workflow_rows
+
+        report = {
+            "workflow_changes": [
+                {
+                    "workflow_path": "gpu_unit_tests.yml",
+                    "workflow_status": "modified",
+                    "case_count_base": 10,
+                    "case_count_head": 12,
+                    "ut_gap_count": 2,
+                    "st_gap_count": 0,
+                    "commit_hashes": ("abc123",),
+                }
+            ]
+        }
+        rows = _past_workflow_rows(report)
+        assert len(rows) >= 2
+        assert rows[1][1] == "modified"
+
+    def test_past_case_rows(self):
+        from modules.excel import _past_case_rows
+
+        report = {
+            "case_details": [
+                {
+                    "workflow_path": "gpu_unit_tests.yml",
+                    "case_name": "tests/test_new.py::test_feature",
+                    "case_kind": "ut",
+                    "target": "tests/test_new.py",
+                    "line_number": 10,
+                    "workflow_context": "GPU Tests / unit-tests / Run pytest",
+                    "signature": "pytest",
+                    "npu_status": "missing_in_npu_workflows",
+                    "npu_refs": [],
+                    "commit_hashes": ("abc123",),
+                }
+            ]
+        }
+        rows = _past_case_rows(report)
+        assert len(rows) >= 2
+
+    def test_past_detail_rows(self):
+        from modules.excel import _past_detail_rows
+
+        report = {
+            "commit_details": [
+                {
+                    "commit_hash": "abc123def456",
+                    "commit_time": "2026-05-30T00:00:00+00:00",
+                    "commit_title": "Add new test",
+                    "affected_workflows": ("gpu_unit_tests.yml",),
+                }
+            ]
+        }
+        rows = _past_detail_rows(report)
+        assert len(rows) >= 2
+        assert any("abc123def456" in str(cell) for cell in rows[1])

--- a/tests/ascend_ci_case_diff_scan/test_excel.py
+++ b/tests/ascend_ci_case_diff_scan/test_excel.py
@@ -20,8 +20,7 @@ class TestXmlText:
         from modules.excel import _xml_text
 
         result = _xml_text("<test>")
-        assert "&lt;" in result
-        assert "&gt;" in result
+        assert result == "&lt;test&gt;"
 
     def test_strips_invalid_xml_chars(self):
         from xml.sax.saxutils import escape
@@ -192,6 +191,10 @@ class TestSideCells:
         assert cells[0] == "a.yml"
         assert cells[1] == 10
         assert "GPU Tests" in cells[2]
+        assert "unit-tests" in cells[2]
+        assert "Run pytest" in cells[2]
+        assert cells[3] == "pytest"
+        assert cells[4] == "pytest tests/"
 
     def test_with_none(self):
         from modules.excel import _side_cells
@@ -493,8 +496,10 @@ class TestWriteExcelReport:
 
             write_excel_report(path, report)
 
-            # Verify ZipFile was created with the right path
-            mock_zip.assert_called_once()
+            # Verify ZipFile was created with the right path and write mode
+            from zipfile import ZIP_DEFLATED
+
+            mock_zip.assert_called_once_with(path, "w", ZIP_DEFLATED)
 
             # Verify writestr was called for each required file
             written_names = {args[0][0] for args in mock_zip_instance.writestr.call_args_list}
@@ -532,6 +537,10 @@ class TestWritePastCommitExcelReport:
             mock_zip.return_value.__enter__.return_value = mock_zip_instance
 
             write_past_commit_excel_report(path, report)
+
+            from zipfile import ZIP_DEFLATED
+
+            mock_zip.assert_called_once_with(path, "w", ZIP_DEFLATED)
 
             written_names = {args[0][0] for args in mock_zip_instance.writestr.call_args_list}
             assert "xl/worksheets/sheet1.xml" in written_names  # Summary

--- a/tests/ascend_ci_case_diff_scan/test_render.py
+++ b/tests/ascend_ci_case_diff_scan/test_render.py
@@ -127,6 +127,7 @@ class TestRenderTable:
         result = render_table(["Col A", "Col B"], [["1", "2"], ["3", "4"]])
         text = "\n".join(result)
 
+        assert len(result) == 4
         assert "Col A" in text
         assert "Col B" in text
         assert "---" in text

--- a/tests/ascend_ci_case_diff_scan/test_render.py
+++ b/tests/ascend_ci_case_diff_scan/test_render.py
@@ -1,0 +1,523 @@
+"""Tests for modules/render.py."""
+
+from __future__ import annotations
+
+# ============================================================================
+# render_reference_details
+# ============================================================================
+
+
+class TestRenderReferenceDetails:
+    def test_with_full_ref(self):
+        from modules.render import render_reference_details
+
+        ref = {
+            "name": "tests/test_foo.py::test_add",
+            "workflow_path": ".github/workflows/test.yml",
+            "line_number": 10,
+            "workflow_name": "GPU Tests",
+            "job_name": "unit-tests",
+            "step_name": "Run pytest",
+            "signature": "pytest",
+            "raw_command": "pytest tests/",
+        }
+        lines = render_reference_details("  ", "CPU/GPU", ref)
+        text = "\n".join(lines)
+
+        assert "CPU/GPU:" in text
+        assert ".github/workflows/test.yml" in text
+        assert "10" in text
+        assert "GPU Tests" in text
+        assert "unit-tests" in text
+        assert "Run pytest" in text
+
+    def test_with_none_ref(self):
+        from modules.render import render_reference_details
+
+        lines = render_reference_details("  ", "NPU", None)
+        text = "\n".join(lines)
+
+        assert "NPU:" in text
+        assert "None" in text
+
+
+# ============================================================================
+# render_adjacent_pairs
+# ============================================================================
+
+
+class TestRenderAdjacentPairs:
+    def test_both_non_empty(self):
+        from modules.render import render_adjacent_pairs
+
+        cpu_refs = [
+            {
+                "name": "tests/test_a.py::test_1",
+                "workflow_path": "a.yml",
+                "line_number": 1,
+                "workflow_name": "A",
+                "job_name": "j",
+                "step_name": "s",
+                "signature": "pytest",
+                "raw_command": "pytest tests/",
+            }
+        ]
+        npu_refs = [
+            {
+                "name": "tests/test_a.py::test_1",
+                "workflow_path": "a_ascend.yml",
+                "line_number": 2,
+                "workflow_name": "A Ascend",
+                "job_name": "j",
+                "step_name": "s",
+                "signature": "pytest",
+                "raw_command": "pytest tests/",
+            }
+        ]
+
+        lines = render_adjacent_pairs(cpu_refs, npu_refs)
+        text = "\n".join(lines)
+
+        assert "Pair 1" in text
+        assert "CPU/GPU" in text
+        assert "NPU" in text
+
+    def test_one_empty(self):
+        from modules.render import render_adjacent_pairs
+
+        cpu_refs = [
+            {
+                "name": "tests/test_a.py::test_1",
+                "workflow_path": "a.yml",
+                "line_number": 1,
+                "workflow_name": "A",
+                "job_name": "j",
+                "step_name": "s",
+                "signature": "pytest",
+                "raw_command": "pytest tests/",
+            }
+        ]
+
+        lines = render_adjacent_pairs(cpu_refs, [])
+        text = "\n".join(lines)
+
+        assert "Pair 1" in text
+        assert "CPU/GPU" in text
+        # NPU ref is None but still rendered
+        assert "NPU:" in text
+
+    def test_both_empty(self):
+        from modules.render import render_adjacent_pairs
+
+        lines = render_adjacent_pairs([], [])
+        text = "\n".join(lines)
+
+        assert "None" in text
+
+
+# ============================================================================
+# render_table
+# ============================================================================
+
+
+class TestRenderTable:
+    def test_simple_table(self):
+        from modules.render import render_table
+
+        result = render_table(["Col A", "Col B"], [["1", "2"], ["3", "4"]])
+        text = "\n".join(result)
+
+        assert "Col A" in text
+        assert "Col B" in text
+        assert "---" in text
+        assert "1" in text
+        assert "4" in text
+
+    def test_empty_rows(self):
+        from modules.render import render_table
+
+        result = render_table(["Header"], [])
+        text = "\n".join(result)
+
+        assert "Header" in text
+        assert "---" in text
+        # Only header + separator, no data rows
+        assert len(result) == 2
+
+
+# ============================================================================
+# render_case_section
+# ============================================================================
+
+
+class TestRenderCaseSection:
+    def test_empty_items(self):
+        from modules.render import render_case_section
+
+        lines = render_case_section("Test Section", [])
+        text = "\n".join(lines)
+
+        assert "### Test Section" in text
+        assert "- None" in text
+
+    def test_with_items(self):
+        from modules.render import render_case_section
+
+        items = [
+            {
+                "name": "tests/test_foo.py::test_add",
+                "command_type": "pytest",
+                "signature": "pytest",
+                "cpu_gpu_refs": [
+                    {
+                        "name": "tests/test_foo.py::test_add",
+                        "workflow_path": "a.yml",
+                        "line_number": 1,
+                        "workflow_name": "A",
+                        "job_name": "j",
+                        "step_name": "s",
+                        "signature": "pytest",
+                        "raw_command": "pytest tests/",
+                    }
+                ],
+                "npu_refs": [],
+            }
+        ]
+
+        lines = render_case_section("Matched Cases", items)
+        text = "\n".join(lines)
+
+        assert "### Matched Cases" in text
+        assert "tests/test_foo.py::test_add" in text
+        assert "CPU/GPU" in text
+
+
+# ============================================================================
+# markdown_table_multiline
+# ============================================================================
+
+
+class TestMarkdownTableMultiline:
+    def test_replaces_br(self):
+        from modules.render import markdown_table_multiline
+
+        result = markdown_table_multiline("a<br>b")
+        assert result == "a<br/>b"
+
+    def test_no_br(self):
+        from modules.render import markdown_table_multiline
+
+        result = markdown_table_multiline("plain text")
+        assert result == "plain text"
+
+    def test_multiple_br(self):
+        from modules.render import markdown_table_multiline
+
+        result = markdown_table_multiline("a<br>b<br>c")
+        assert result == "a<br/>b<br/>c"
+
+    def test_empty_string(self):
+        from modules.render import markdown_table_multiline
+
+        result = markdown_table_multiline("")
+        assert result == ""
+
+
+# ============================================================================
+# render_scanned_workflows
+# ============================================================================
+
+
+class TestRenderScannedWorkflows:
+    def test_empty(self):
+        from modules.render import render_scanned_workflows
+
+        lines = render_scanned_workflows([])
+        text = "\n".join(lines)
+
+        assert "No workflows were scanned" in text
+
+    def test_with_rows(self):
+        from modules.render import render_scanned_workflows
+
+        rows = [
+            {
+                "workflow_name": "gpu_unit_tests.yml (GPU Unit Tests)",
+                "cpu_gpu_case_count": 42,
+                "npu_supported_case_count": 38,
+            }
+        ]
+
+        lines = render_scanned_workflows(rows)
+        text = "\n".join(lines)
+
+        assert "Workflow Name" in text
+        assert "CPU/GPU Case Count" in text
+        assert "NPU Supported Case Count" in text
+        assert "gpu_unit_tests.yml" in text
+        assert "42" in text
+        assert "38" in text
+
+
+# ============================================================================
+# render_report (integration)
+# ============================================================================
+
+
+class TestRenderReport:
+    def test_full_report_structure(self):
+        from modules.render import render_report
+
+        report = {
+            "repo_root": "/fake/repo",
+            "generated_at": "2026-05-30T00:00:00+00:00",
+            "ignored_workflows": ["docker-build.yml"],
+            "scanned_workflows": [],
+            "ut_details": {
+                "matched": [],
+                "cpu_gpu_only": [],
+                "npu_only": [],
+                "manual_review": [],
+            },
+            "st_details": {
+                "matched": [],
+                "cpu_gpu_only": [],
+                "npu_only": [],
+                "manual_review": [],
+            },
+        }
+
+        result = render_report(report)
+
+        assert "# Ascend CI Workflow and Case Alignment Report" in result
+        assert "## Ignored Workflows" in result
+        assert "docker-build.yml" in result
+        assert "## Scanned Workflows" in result
+        assert "## UT Case Details" in result
+        assert "## ST Case Details" in result
+        assert "### Matched Cases" in result
+        assert "### CPU/GPU-only Cases" in result
+        assert "### NPU-only Cases" in result
+        assert "### Manual Review" in result
+
+    def test_empty_ignored_workflows(self):
+        from modules.render import render_report
+
+        report = {
+            "repo_root": "/fake/repo",
+            "generated_at": "2026-05-30T00:00:00+00:00",
+            "ignored_workflows": [],
+            "scanned_workflows": [],
+            "ut_details": {
+                "matched": [],
+                "cpu_gpu_only": [],
+                "npu_only": [],
+                "manual_review": [],
+            },
+            "st_details": {
+                "matched": [],
+                "cpu_gpu_only": [],
+                "npu_only": [],
+                "manual_review": [],
+            },
+        }
+
+        result = render_report(report)
+        assert "No workflows were ignored" in result
+
+    def test_with_case_details(self):
+        from modules.render import render_report
+
+        report = {
+            "repo_root": "/fake/repo",
+            "generated_at": "2026-05-30T00:00:00+00:00",
+            "ignored_workflows": [],
+            "scanned_workflows": [],
+            "ut_details": {
+                "matched": [
+                    {
+                        "name": "tests/test_foo.py::test_add",
+                        "command_type": "pytest",
+                        "signature": "pytest",
+                        "cpu_gpu_refs": [
+                            {
+                                "name": "tests/test_foo.py::test_add",
+                                "workflow_path": "a.yml",
+                                "line_number": 1,
+                                "workflow_name": "A",
+                                "job_name": "j",
+                                "step_name": "s",
+                                "signature": "pytest",
+                                "raw_command": "pytest tests/",
+                            }
+                        ],
+                        "npu_refs": [],
+                    }
+                ],
+                "cpu_gpu_only": [],
+                "npu_only": [],
+                "manual_review": [],
+            },
+            "st_details": {
+                "matched": [],
+                "cpu_gpu_only": [],
+                "npu_only": [],
+                "manual_review": [],
+            },
+        }
+
+        result = render_report(report)
+        assert "tests/test_foo.py::test_add" in result
+
+    def test_result_ends_with_newline(self):
+        from modules.render import render_report
+
+        report = {
+            "repo_root": "/fake/repo",
+            "generated_at": "2026-05-30T00:00:00+00:00",
+            "ignored_workflows": [],
+            "scanned_workflows": [],
+            "ut_details": {
+                "matched": [],
+                "cpu_gpu_only": [],
+                "npu_only": [],
+                "manual_review": [],
+            },
+            "st_details": {
+                "matched": [],
+                "cpu_gpu_only": [],
+                "npu_only": [],
+                "manual_review": [],
+            },
+        }
+
+        result = render_report(report)
+        assert result.endswith("\n")
+
+
+# ============================================================================
+# render_past_commit_report
+# ============================================================================
+
+
+class TestRenderPastCommitReport:
+    def test_empty_report(self):
+        from modules.render import render_past_commit_report
+
+        report = {
+            "repo_root": "/fake/repo",
+            "since_days": 7,
+            "commit_count": 0,
+            "summary": [],
+            "workflow_changes": [],
+            "case_details": [],
+            "commit_details": [],
+        }
+
+        result = render_past_commit_report(report)
+
+        assert "# Ascend CI Past N Days Commit Analysis" in result
+        assert "/fake/repo" in result
+        assert "7" in result
+        assert "0" in result
+
+    def test_with_data(self):
+        from modules.render import render_past_commit_report
+
+        report = {
+            "repo_root": "/fake/repo",
+            "since_days": 7,
+            "commit_count": 2,
+            "summary": [
+                {
+                    "affected_path": "gpu_unit_tests.yml",
+                    "ut_gap_count": 3,
+                    "st_gap_count": 1,
+                }
+            ],
+            "workflow_changes": [
+                {
+                    "workflow_path": "gpu_unit_tests.yml",
+                    "workflow_status": "modified",
+                    "case_count_base": 10,
+                    "case_count_head": 12,
+                    "ut_gap_count": 2,
+                    "st_gap_count": 0,
+                    "commit_hashes": ("abc123def456",),
+                }
+            ],
+            "case_details": [
+                {
+                    "case_name": "tests/test_new.py::test_feature",
+                    "case_kind": "ut",
+                    "workflow_path": "gpu_unit_tests.yml",
+                    "line_number": 10,
+                    "workflow_context": "GPU Tests / unit-tests / Run pytest",
+                    "signature": "pytest",
+                    "raw_command": "pytest tests/",
+                    "npu_status": "missing_in_npu_workflows",
+                    "npu_refs": [],
+                    "commit_hashes": ("abc123def456",),
+                }
+            ],
+            "commit_details": [
+                {
+                    "commit_hash": "abc123def456",
+                    "commit_time": "2026-05-30T00:00:00+00:00",
+                    "commit_title": "Add new test",
+                    "changed_files": ("tests/test_new.py",),
+                    "affected_workflows": ("gpu_unit_tests.yml",),
+                }
+            ],
+        }
+
+        result = render_past_commit_report(report)
+
+        assert "## Summary" in result
+        assert "## Changed Workflows" in result
+        assert "## Changed Case Details" in result
+        assert "## Commit Details" in result
+        assert "gpu_unit_tests.yml" in result
+        assert "tests/test_new.py::test_feature" in result
+
+    def test_with_npu_refs(self):
+        """Cover L225-227: rendering non-empty npu_refs."""
+        from modules.render import render_past_commit_report
+
+        report = {
+            "repo_root": "/fake/repo",
+            "since_days": 7,
+            "commit_count": 1,
+            "summary": [],
+            "workflow_changes": [],
+            "case_details": [
+                {
+                    "case_name": "tests/test_foo.py::test_bar",
+                    "case_kind": "ut",
+                    "workflow_path": "gpu.yml",
+                    "line_number": 10,
+                    "workflow_context": "GPU Tests / unit-tests / Run pytest",
+                    "signature": "pytest",
+                    "raw_command": "pytest tests/",
+                    "npu_status": "aligned",
+                    "npu_refs": [
+                        {
+                            "workflow_name": "NPU Tests",
+                            "job_name": "unit-tests",
+                            "step_name": "Run pytest",
+                            "workflow_path": "npu.yml",
+                            "line_number": 12,
+                        }
+                    ],
+                    "commit_hashes": ("abc123",),
+                }
+            ],
+            "commit_details": [],
+        }
+
+        result = render_past_commit_report(report)
+
+        assert "NPU refs:" in result
+        assert "NPU Tests" in result
+        assert "npu.yml" in result
+        assert "NPU refs: None" not in result


### PR DESCRIPTION
## Summary

Improve test coverage and fix code quality issues in `test_excel.py` and `test_render.py`.

## Coverage

| Source Module | Stmts | Coverage | Test File | Cases |
|---------------|-------|----------|-----------|-------|
| `excel.py` | 129 | **100%** | `test_excel.py` | 45 |
| `render.py` | 102 | **100%** | `test_render.py` | 22 |
| **Total** | **231** | **100%** | | **67** |

## Changes

### test_excel.py

**New tests (6):**

| Test | Rationale |
|------|-----------|
| `test_zero_returns_empty` | `_column_name(0)` edge case |
| `test_multiple_br` | `_excel_multiline` with multiple `<br>` tags |
| `test_empty_string` | `_excel_multiline` with empty input |
| `test_cell_xml_none_value` | `_cell_xml` with `None` value |
| `test_case_rows_with_non_empty_section` | `_case_rows` with non-empty detail sections |
| _(assertion strengthened)_ | `test_past_case_rows` / `test_past_detail_rows` |

**Fixes (4):**

| Line | Issue | Fix |
|------|-------|-----|
| L6 | Unused `from pathlib import Path` | Removed |
| L8 | Unused `import pytest` | Removed |
| L114 | `DEFAULT_COLUMN_WIDTH` imported but unused in `test_within_range` | Removed from that import |
| L606, L623 | `test_past_case_rows` only checked `len >= 2`; `test_past_detail_rows` used `any(str(cell))` substring match | Replaced with exact column assertions |

### test_render.py

| Line | Issue | Fix |
|------|-------|-----|
| L5 | Unused `import pytest` | Removed |