### PR TITLE
docs: refine ascend-ci-case-diff-scan SKILL.md following writing-skills best practices

### DIFF
--- a/.agent/skills/ascend-ci-case-diff-scan/README.md
+++ b/.agent/skills/ascend-ci-case-diff-scan/README.md
@@ -1,63 +1,33 @@
 # Ascend CI Case Diff Scan
 
-This skill statically audits a target `verl` repository and reports workflow/case alignment between CPU/GPU and NPU workflows.
+Statically audit test-case coverage alignment between CPU/GPU and Ascend NPU CI workflows in a `verl` repository. See [SKILL.md](./SKILL.md) for the full skill reference.
 
-## What it does
-
-- Excludes non-test and non-comparable workflows through `config/workflow_scope.json`
-- Pairs CPU/GPU workflows with their NPU counterparts
-- Counts UT cases at the test-function or test-method level
-- Counts ST cases at the command level
-- Writes English `report.md` and `report.xlsx` files
-- Optionally writes `report-past-N.md` and `report-past-N.xlsx` for recent merged commits when `--since-days N` is set
-
-## Workflow pairing
-
-- `foo.yml` pairs with `foo_ascend.yml`
-- `gpu_unit_tests.yml` pairs with `npu_unit_tests.yml`
-- Standalone NPU workflows such as `e2e_ascend.yml` and `nightly_ascend.yml` remain NPU-only
-
-## How cases are classified
-
-- `pytest` commands → **UT** cases, expanded to function-level (`test_*` / `Test*::test_*`) whenever the Python file can be parsed
-- `torchrun`, `bash tests/*.sh`, and `bash examples/*.sh` → **ST** cases, recorded at the command level
-- Repeated commands are kept distinct by `workflow name`, `job name`, and `step name`
-
-## CLI usage
+## Quick start
 
 ```bash
 python scripts/scan_ascend_ci_case_diff.py \
   --repo-root {PATH}/verl \
   --output-dir ./outputs
+
+# With past-N-days incremental analysis
+python scripts/scan_ascend_ci_case_diff.py \
+  --repo-root {PATH}/verl \
+  --output-dir ./outputs \
+  --since-days 7
 ```
-
-- `--repo-root` — path to the target `verl` repository root
-- `--since-days N` — (optional) also generate a past-N-days report; must be a positive integer
-
-## Past-N-days behavior
-
-- Walks first-parent history for merged commits in the last `N` days
-- Reports only effective final-state changes (additions later removed or reverted are excluded)
-- `Related Commits` lists commits that touched the workflow or the changed case target
 
 ## Output
 
-The reports include:
+- `report.md` + `report.xlsx` — full audit (4 sheets: Ignored Workflows, Scanned Workflows, UT Cases, ST Cases)
+- `report-past-N.md` + `report-past-N.xlsx` — incremental analysis (only when `--since-days` is set)
 
-- ignored workflows
-- scanned workflows with CPU/GPU and NPU case counts
-- UT details
-- ST details
+## Project structure
 
-Past-N-days reports also include:
-
-- a summary of CPU/GPU workflows that are not fully aligned with NPU
-- changed workflow rows with window-start and current-HEAD case counts
-- changed case details with signatures and related commits
-- commit details for the merged commits inside the selected window
-
-Within UT and ST sections, the report shows matched, CPU/GPU-only, NPU-only, and manual-review cases in that order, with adjacent CPU/GPU and NPU references for easy comparison.
-
-The Excel workbook contains four sheets: `Ignored Workflows`, `Scanned Workflows`, `UT Cases`, and `ST Cases`.
-
-The past-N-days workbook contains summary, changed-workflow, changed-case, and commit-detail sheets.
+```
+SKILL.md                  # Skill reference (loaded by Claude Code)
+README.md                 # This file
+doc.md                    # Design document (Chinese)
+config/workflow_scope.json # Ignored workflow patterns
+references/repo-signals.md # Target-repo signal definitions
+scripts/                  # Python scanner implementation
+```

--- a/.agent/skills/ascend-ci-case-diff-scan/SKILL.md
+++ b/.agent/skills/ascend-ci-case-diff-scan/SKILL.md
@@ -1,58 +1,69 @@
 ---
 name: ascend-ci-case-diff-scan
-description: Scan an external verl repository for Ascend/NPU CI coverage gaps by comparing CPU/GPU workflow cases against NPU workflows. Use when Codex needs to audit workflow and case-level parity or generate Markdown and Excel reports about workflow execution differences.
+description: Use when auditing Ascend/NPU CI test coverage in a verl repository, checking whether CPU/GPU workflow test cases have corresponding NPU workflow coverage, or identifying test cases missing from NPU CI workflows
 ---
 
 # Ascend CI Case Diff Scan
 
-Audit Ascend CI coverage in a target `verl` repository with the scanner shipped in this skill.
+Static analyzer that compares CPU/GPU workflow test cases against Ascend NPU workflow coverage in a `verl` repository. Reads GitHub Actions `run:` commands, preserves workflow/job/step context, and does not execute tests.
 
-## Overview
+## Quick Reference
 
-Use this skill when you need to compare CPU/GPU workflow test coverage with NPU workflow coverage and produce English Markdown and Excel reports. The scanner is static: it reads GitHub Actions workflow `run:` commands, preserves workflow/job/step context, and does not execute tests.
+| | |
+|---|---|
+| **Input** | `.github/workflows/*.yml` in target verl repo |
+| **UT extraction** | `pytest ... tests/...` → function-level (`test_*` / `Test*::test_*`) via AST |
+| **ST extraction** | `bash tests/*.sh`, `bash examples/*.sh`, `torchrun ... tests/...` → command-level |
+| **Classification** | `aligned` → `manual_review_needed` → `missing_in_npu_workflows` / `npu_only` |
+| **Output** | `report.md` + `report.xlsx` (4 sheets) |
+| **Past-N-days** | `--since-days N` adds `report-past-N.md` + `report-past-N.xlsx` |
+| **Config** | `config/workflow_scope.json` — ignored workflow glob patterns |
 
-The full reports show ignored workflows, paired CPU/GPU and NPU workflows, UT/ST case counts, matched cases, missing cases, NPU-only cases, and manual-review cases. When `--since-days N` is set, the scanner also emits a past-N-days report that surfaces only CPU/GPU workflows and UT/ST cases with effective changes in the selected window, then checks those changed cases against the current HEAD NPU support evidence.
+## When to Use
+
+- Auditing NPU CI coverage before a release
+- Checking whether recent CPU/GPU workflow changes have NPU equivalents
+- Generating coverage gap reports for stakeholders
+- CI pipeline integration for automated parity checks
+
+**Don't use for:** executing tests, modifying workflow files, or analyzing non-GitHub-Actions CI systems.
 
 ## Instructions
 
 1. Read [references/repo-signals.md](./references/repo-signals.md) for repo-specific boundaries.
-2. Identify the target `verl` repository root, for example `{PATH}/verl`.
-3. Run the scanner. The commands below assume the working directory is the root of `verl-ascend-recipe` (where `.agent/` lives). You can also `cd` into `scripts/` and run `python scan_ascend_ci_case_diff.py ...` directly.
+2. Identify the target `verl` repository root.
+3. Run from the `verl-ascend-recipe` root (where `.agent/` lives):
 
 ```shell
+# Full audit
 python .agent/skills/ascend-ci-case-diff-scan/scripts/scan_ascend_ci_case_diff.py \
   --repo-root {PATH}/verl \
   --output-dir ./report/ascend-ci-case-diff-scan
-```
 
-Optional:
-
-```shell
+# With past-N-days incremental analysis
 python .agent/skills/ascend-ci-case-diff-scan/scripts/scan_ascend_ci_case_diff.py \
   --repo-root {PATH}/verl \
   --output-dir ./report/ascend-ci-case-diff-scan \
   --since-days 7
 ```
 
-`--since-days` must be a positive integer. If it is omitted, only the full report is generated.
+`--since-days` must be a positive integer. Omit to generate only the full report.
 
 ## Extraction Rules
 
-Recognize only workflow commands that visibly execute tests (see [references/repo-signals.md](./references/repo-signals.md#extractable-command-forms) for details):
+Recognize only these command forms (see [references/repo-signals.md](./references/repo-signals.md#extractable-command-forms)):
 
 - `pytest ... tests/...`
 - `bash tests/.../*.sh` or `bash examples/.../*.sh`
 - `torchrun ... tests/...`
 
-For each extracted case, preserve: `workflow_name`, `job_name`, `step_name`, `command_type`, `target`, `raw_command`, `signature`.
+For each extracted case, preserve: `workflow_name`, `job_name`, `step_name`, `command_type`, `target`, `raw_command`, `signature`. Keep cases distinct when the same command appears in different workflow/job/step contexts. For UT, expand to function-level or test-method-level whenever the target file can be parsed. For ST, record only scripts explicitly invoked — do not inspect the script body.
 
-When the same command appears in different workflow/job/step contexts, keep cases distinct. For UT, expand to function-level or test-method-level whenever the target file can be parsed. For ST scripts, record only scripts explicitly invoked by the workflow step — do not inspect the script body.
-
-Case matching uses `command_type`, `target`, and `signature` (see [references/repo-signals.md](./references/repo-signals.md#matching-expectations) for detailed matching rules).
+Case matching uses `command_type`, `target`, and `signature` (see [references/repo-signals.md](./references/repo-signals.md#matching-expectations)).
 
 ## Past-N-Days Analysis
 
-When `--since-days N` is set, the scanner walks the current branch first-parent history for commits merged in the last `N` days, compares the window-start snapshot with current `HEAD`, and reports only effective final-state changes. See [references/repo-signals.md](./references/repo-signals.md#past-n-days-expectations) for the full scoping and column semantics.
+When `--since-days N` is set, the scanner walks first-parent history for commits merged in the last `N` days, compares the window-start snapshot with current `HEAD`, and reports only effective final-state changes. See [references/repo-signals.md](./references/repo-signals.md#past-n-days-expectations) for full scoping and column semantics.
 
 ## Boundaries
 
@@ -62,22 +73,50 @@ When `--since-days N` is set, the scanner walks the current branch first-parent 
 - Do not expand GitHub Actions matrices.
 - Keep the final report in English only.
 
-## Classification Rules
+## Case Classification
 
-Output categories: `aligned`, `missing_in_npu_workflows`, `manual_review_needed`, `npu_only`.
+```dot
+digraph case_classification {
+    rankdir=TB
+    node [fontname="Arial", fontsize=11]
+    edge [fontname="Arial", fontsize=9]
 
-Exact target matches are the strongest signal; different signatures for the same target fall back to `manual_review_needed`. See [references/repo-signals.md](./references/repo-signals.md#matching-expectations) for the full matching rules.
+    start [shape=point]
+    l3 [label="Exact match on\n(command_type, target, signature)?", shape=diamond]
+    aligned [label="aligned", shape=box]
+    l2 [label="Same (command_type, target)\nwith different signatures?", shape=diamond]
+    both [label="Both sides have\ndifferent signatures?", shape=diamond]
+    manual [label="manual_review_needed", shape=box]
+    cpu_only [label="Only CPU/GPU side?", shape=diamond]
+    missing [label="missing_in_npu_workflows", shape=box]
+    npu_only [label="npu_only", shape=box]
+
+    start -> l3
+    l3 -> aligned [label="yes"]
+    l3 -> l2 [label="no"]
+    l2 -> both [label="yes"]
+    both -> manual [label="yes"]
+    both -> cpu_only [label="no"]
+    cpu_only -> missing [label="yes"]
+    cpu_only -> npu_only [label="no"]
+}
+```
+
+The classification algorithm checks in this order (strongest signal first): exact three-key match → same target with signature divergence → side-only. The report displays sections as: **Matched Cases**, **CPU/GPU-only Cases**, **NPU-only Cases**, **Manual Review** — in that order. See [references/repo-signals.md](./references/repo-signals.md#matching-expectations) for detailed matching rules.
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Expecting matrix expansion | Matrix strategies are not expanded. Dynamic test combinations from `strategy.matrix` are not detected. |
+| `--since-days` ≤ 0 | Must be a positive integer. Zero or negative values raise `ValueError`. |
+| Running against wrong directory | The script validates that `--repo-root` contains `.github/workflows/`. |
+| Assuming ST script internals are analyzed | Only ST commands are recorded at the command level. Script bodies (`.sh`, Python) are not inspected for nested test calls. |
+| Treating `manual_review_needed` as failure | Same-target/different-signature cases may still be functionally equivalent — they need human judgment, not automation. |
+| Expecting NPU workflows as primary past-N-days rows | The past-N-days changed-workflow table is CPU/GPU-oriented. NPU workflows appear as support references only. |
 
 ## Reporting
 
-The scanner writes `report.md` and `report.xlsx` to the requested output directory.
-If `--since-days` is provided, it also writes `report-past-N.md` and `report-past-N.xlsx`.
+The scanner writes `report.md` and `report.xlsx` to `--output-dir`. With `--since-days`, it also writes `report-past-N.md` and `report-past-N.xlsx`.
 
-The reports contain:
-
-- ignored workflows
-- scanned workflows with CPU/GPU and NPU case counts
-- UT details
-- ST details
-
-Within the UT and ST sections, matched, CPU/GPU-only, NPU-only, and manual-review cases are shown in that order, with CPU/GPU and NPU references adjacent for easier comparison. The Excel workbook stores these sections as four sheets: `Ignored Workflows`, `Scanned Workflows`, `UT Cases`, and `ST Cases`.
+Reports contain: ignored workflows, scanned workflows with CPU/GPU and NPU case counts, UT details, ST details (matched, CPU/GPU-only, NPU-only, manual-review cases in that order with adjacent CPU/GPU and NPU references). The Excel workbook stores these as four sheets: `Ignored Workflows`, `Scanned Workflows`, `UT Cases`, `ST Cases`.


### PR DESCRIPTION
## Summary

Refine the `ascend-ci-case-diff-scan` skill documentation to align with
[writing-skills](https://agentskills.io/specification) best practices.

## Changes

### SKILL.md

- **Fix frontmatter `description`** — now starts with "Use when..." and describes
  only triggering conditions (third person, no workflow summary), preventing
  Claude from following the description shortcut instead of reading the full skill.
- **Add Quick Reference table** — input, extraction, classification, output, config
  at a glance for returning users.
- **Add Case Classification flowchart (dot)** — visualizes the four-category
  decision tree since the priority order is non-obvious.
- **Clarify classification order vs display order** — previously the text
  described classification algorithm priority (`aligned → manual_review →
  missing/npu_only`) which did not match the report display order
  (`Matched → CPU/GPU-only → NPU-only → Manual Review`). Now both are
  explicitly stated.
- **Add Common Mistakes section** — 6 frequent pitfalls with fixes (matrix
  expansion, `--since-days` validation, ST script assumptions, etc.).

### README.md

- **Reduce redundancy** — remove duplicated CLI usage, workflow pairing, and
  case classification details already covered in SKILL.md. Keep only a quick
  start and project structure overview.