### PR TITLE
fix(true-on-policy): refresh verl main patch contexts

### DIFF
--- a/true_on_policy/patch/verl_patches/verl_npu_pp_per_request_seed_main.patch
+++ b/true_on_policy/patch/verl_patches/verl_npu_pp_per_request_seed_main.patch
@@ -1,30 +1,20 @@
 diff --git a/docs/index.rst b/docs/index.rst
-index 6b6f9acb7013ee8534fd3080375cb913e3cd271c..2d84ca12d03669db2383678dfe0750964ef7ef69 100644
+index 5209ad9d..361e31a7 100644
 --- a/docs/index.rst
 +++ b/docs/index.rst
-@@ -150,6 +150,7 @@ verl is fast with:
-    advance/skip_manager.rst
-    advance/agent_loop
+@@ -154,2 +154,3 @@ verl is fast with:
     advance/reward_loop
 +   advance/per_request_seed.md
     data/transfer_queue.md
-    advance/grafana_prometheus.md
-    advance/mtp.md
 diff --git a/verl/experimental/agent_loop/agent_loop.py b/verl/experimental/agent_loop/agent_loop.py
-index 1bd98610dbb5f668d697dbc9c0563c752410e72b..b7d0d5250f2a479ba5a94a0131dd1700d059fe9f 100644
+index 1bd98610..b7d0d525 100644
 --- a/verl/experimental/agent_loop/agent_loop.py
 +++ b/verl/experimental/agent_loop/agent_loop.py
-@@ -71,6 +71,7 @@ from verl.workers.config import (
-     RolloutConfig,
- )
+@@ -73,2 +73,3 @@ from verl.workers.config import (
  from verl.workers.rollout.llm_server import LLMServerClient
 +from verl.workers.rollout.utils import maybe_apply_per_request_seed
  
- logger = logging.getLogger(__file__)
- logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
-@@ -646,9 +647,18 @@ class AgentLoopWorker:
-             sample_sampling_params = dict(sampling_params)
-             if not validate and per_sample_do_sample is not None and not bool(per_sample_do_sample[i]):
+@@ -648,5 +649,14 @@ class AgentLoopWorker:
                  apply_greedy_sampling_params(sample_sampling_params)
 +            traj = trajectory_info[i]
 +            maybe_apply_per_request_seed(
@@ -40,15 +30,11 @@ index 1bd98610dbb5f668d697dbc9c0563c752410e72b..b7d0d5250f2a479ba5a94a0131dd1700
 -                    self._run_agent_loop(sample_sampling_params, trajectory_info[i], trace=trace_this_sample, **kwargs)
 +                    self._run_agent_loop(sample_sampling_params, traj, trace=trace_this_sample, **kwargs)
                  )
-             )
-         outputs = await asyncio.gather(*tasks)
 diff --git a/verl/trainer/config/rollout/rollout.yaml b/verl/trainer/config/rollout/rollout.yaml
-index e7373ef780e31bc16c8f0884bf7ee4e629133628..fc5a7c96f3ec1591c44c0344a73295640dfe337b 100644
+index e7373ef7..fc5a7c96 100644
 --- a/verl/trainer/config/rollout/rollout.yaml
 +++ b/verl/trainer/config/rollout/rollout.yaml
-@@ -30,6 +30,13 @@ full_determinism: false
- # enable_full_determinism() when full_determinism is True.
- seed: 42
+@@ -32,2 +32,9 @@ seed: 42
  
 +# Script toggle: set actor_rollout_ref.rollout.per_request_seed=true to enable.
 +# When false (default), rollout behaves as before unless full_determinism injects
@@ -58,23 +44,15 @@ index e7373ef780e31bc16c8f0884bf7ee4e629133628..fc5a7c96f3ec1591c44c0344a7329564
 +per_request_seed: false
 +
  # typically the same as data max prompt length
- # same as data.max_prompt_length if it exists
- prompt_length: ${oc.select:data.max_prompt_length,512}
 diff --git a/verl/trainer/ppo/v1/agent_loop_tq.py b/verl/trainer/ppo/v1/agent_loop_tq.py
-index 5e147eef223f65e9ca72f86d11a933af44daa00c..f4a40422aafcd0aba82a9736d41bb84409232ed3 100644
+index 5e147eef..f4a40422 100644
 --- a/verl/trainer/ppo/v1/agent_loop_tq.py
 +++ b/verl/trainer/ppo/v1/agent_loop_tq.py
-@@ -33,6 +33,7 @@ from verl.experimental.agent_loop import (
- )
- from verl.utils.ray_utils import auto_await
+@@ -35,2 +35,3 @@ from verl.utils.ray_utils import auto_await
  from verl.utils.tensordict_utils import list_of_dict_to_tensordict
 +from verl.workers.rollout.utils import maybe_apply_per_request_seed
  
- logger = logging.getLogger(__name__)
- logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "INFO"))
-@@ -113,11 +114,23 @@ class AgentLoopWorkerTQ(AgentLoopWorker):
-             if not trajectory["validate"] and not do_sample:
-                 apply_greedy_sampling_params(run_sampling_params)
+@@ -115,7 +116,19 @@ class AgentLoopWorkerTQ(AgentLoopWorker):
  
 +            per_request_seed = getattr(config, "per_request_seed", False)
 +            base_seed = getattr(config, "seed", None)
@@ -95,31 +73,19 @@ index 5e147eef223f65e9ca72f86d11a933af44daa00c..f4a40422aafcd0aba82a9736d41bb844
 -                        run_sampling_params, trajectory=trajectory, trace=trace, session_id=i, **prompt
 +                        loop_sampling_params, trajectory=trajectory, trace=trace, session_id=i, **prompt
                      )
-                 )
-                 tasks.append(task)
 diff --git a/verl/workers/config/rollout.py b/verl/workers/config/rollout.py
-index 19cf7f5e322909a108a98d501f817f556af88de0..6ad82e7e54e43db4c478adb3d01aaa0daaf0f055 100644
+index 19cf7f5e..6ad82e7e 100644
 --- a/verl/workers/config/rollout.py
 +++ b/verl/workers/config/rollout.py
-@@ -18,6 +18,7 @@ from typing import Optional
- from omegaconf import MISSING, DictConfig, OmegaConf
- 
+@@ -20,2 +20,3 @@ from omegaconf import MISSING, DictConfig, OmegaConf
  from verl.base_config import BaseConfig
 +from verl.utils.device import is_torch_npu_available
  from verl.utils.profiler import ProfilerConfig
- from verl.workers.config.disaggregation import DisaggregationConfig
- from verl.workers.config.model import MtpConfig
-@@ -151,6 +152,7 @@ class RolloutConfig(BaseConfig):
-         "response_length",
-         "expert_parallel_size",
+@@ -153,2 +154,3 @@ class RolloutConfig(BaseConfig):
          "moe_tensor_parallel_size",
 +        "pipeline_model_parallel_size",
          "full_determinism",
-         "max_num_seqs",
-     }
-@@ -174,6 +176,11 @@ class RolloutConfig(BaseConfig):
-     # enable_full_determinism() when full_determinism is True.
-     seed: int = 42
+@@ -176,2 +178,7 @@ class RolloutConfig(BaseConfig):
  
 +    # When True, each generation request gets a unique SamplingParams.seed.
 +    # When False (default), rollout behaves as before unless full_determinism
@@ -127,11 +93,7 @@ index 19cf7f5e322909a108a98d501f817f556af88de0..6ad82e7e54e43db4c478adb3d01aaa0d
 +    per_request_seed: bool = False
 +
      # Early termination threshold for multi-turn rollout in sglang.
-     # Abort remaining requests when (1 - over_sample_rate) * total_requests are completed.
-     over_sample_rate: float = 0.0
-@@ -313,8 +320,33 @@ class RolloutConfig(BaseConfig):
-                     f"tensor_model_parallel_size={self.tensor_model_parallel_size})"
-                 )
+@@ -315,4 +322,29 @@ class RolloutConfig(BaseConfig):
  
 +        if self.name == "vllm" and is_torch_npu_available(check_device=False):
 +            vllm_engine_kwargs = (self.engine_kwargs or {}).get("vllm") or {}
@@ -162,11 +124,7 @@ index 19cf7f5e322909a108a98d501f817f556af88de0..6ad82e7e54e43db4c478adb3d01aaa0d
 +                )
 +            if self.name == "vllm" and not is_torch_npu_available(check_device=False):
                  raise NotImplementedError(
-                     f"Current rollout {self.name=} not implemented pipeline_model_parallel_size > 1 yet."
-                 )
-@@ -339,3 +371,60 @@ class RolloutConfig(BaseConfig):
-             raise ValueError(
-                 f"rollout.disaggregation.enabled=True requires rollout.name in ('sglang', 'vllm'); got {self.name!r}."
+@@ -341 +373,58 @@ class RolloutConfig(BaseConfig):
              )
 +
 +
@@ -226,23 +184,18 @@ index 19cf7f5e322909a108a98d501f817f556af88de0..6ad82e7e54e43db4c478adb3d01aaa0d
 +        * rollout_config.pipeline_model_parallel_size
 +    )
 diff --git a/verl/workers/rollout/llm_server.py b/verl/workers/rollout/llm_server.py
-index d4914039e054557613e75c1f34fe785106563075..97d390670846526e777ba7f62c56d71af7cbd48c 100644
+index 949b9602..caec0974 100644
 --- a/verl/workers/rollout/llm_server.py
 +++ b/verl/workers/rollout/llm_server.py
-@@ -31,8 +31,10 @@ from omegaconf import DictConfig
- 
- from verl.single_controller.ray.base import RayResourcePool, RayWorkerGroup
+@@ -33,2 +33,3 @@ from verl.single_controller.ray.base import RayResourcePool, RayWorkerGroup
  from verl.utils import normalize_token_ids
 +from verl.utils.device import is_torch_npu_available
  from verl.utils.ray_utils import auto_await
- from verl.utils.rollout_trace import rollout_trace_op
+@@ -36,2 +37,3 @@ from verl.utils.rollout_trace import rollout_trace_op
+ from verl.utils.tracking import RLInsightLogger
 +from verl.workers.config.rollout import ensure_rollout_config, get_rollout_parallel_world_size
  from verl.workers.rollout.replica import RolloutReplica, TokenOutput, get_rollout_replica_class
- from verl.workers.rollout.utils import update_prometheus_config
- 
-@@ -380,7 +382,14 @@ class LLMServerManager:
-         start_rank: int = 0,
-     ):
+@@ -383,3 +385,10 @@ class LLMServerManager:
          self.config = config
 -        self.rollout_config = config.actor_rollout_ref.rollout
 +        if is_torch_npu_available(check_device=False):
@@ -254,11 +207,7 @@ index d4914039e054557613e75c1f34fe785106563075..97d390670846526e777ba7f62c56d71a
 +        else:
 +            self.rollout_config = config.actor_rollout_ref.rollout
          self.model_config = config.actor_rollout_ref.model
-         self.worker_group = worker_group
-         self.rollout_resource_pool = rollout_resource_pool
-@@ -414,33 +423,48 @@ class LLMServerManager:
-         """
-         if start_rank is None:
+@@ -417,20 +426,19 @@ class LLMServerManager:
              start_rank = self.start_rank
 -        rollout_world_size = (
 -            self.rollout_config.tensor_model_parallel_size
@@ -294,7 +243,7 @@ index d4914039e054557613e75c1f34fe785106563075..97d390670846526e777ba7f62c56d71a
 -                (prefill_tp * disagg.prefill_replicas + decode_tp * disagg.decode_replicas)
 +                self.rollout_config.tensor_model_parallel_size
                  * self.rollout_config.data_parallel_size
-                 * self.rollout_config.pipeline_model_parallel_size
+@@ -438,8 +446,24 @@ class LLMServerManager:
              )
 -        world_size = (
 -            self.worker_group.world_size
@@ -325,23 +274,15 @@ index d4914039e054557613e75c1f34fe785106563075..97d390670846526e777ba7f62c56d71a
 +            )
 +            num_replicas = world_size // rollout_world_size
  
-         self.rollout_replicas = [
-             self.rollout_replica_class(
 diff --git a/verl/workers/rollout/replica.py b/verl/workers/rollout/replica.py
-index c01cdd79126ffa51ddcb42cdc3ff6529d5c6ecbe..70adbd90b887e6e1d860209fe27d040115ba28ad 100644
+index c01cdd79..70adbd90 100644
 --- a/verl/workers/rollout/replica.py
 +++ b/verl/workers/rollout/replica.py
-@@ -27,6 +27,7 @@ from verl.single_controller.ray import RayClassWithInitArgs, RayResourcePool, Ra
- from verl.utils.config import omega_conf_to_dataclass
- from verl.utils.device import is_torch_npu_available
+@@ -29,2 +29,3 @@ from verl.utils.device import is_torch_npu_available
  from verl.workers.config import HFModelConfig, RolloutConfig
 +from verl.workers.config.rollout import ensure_rollout_config
  
- logger = logging.getLogger(__file__)
- 
-@@ -101,7 +102,10 @@ class RolloutReplica(ABC):
-         name_suffix: str = "",
-     ) -> None:
+@@ -103,3 +104,6 @@ class RolloutReplica(ABC):
          self.replica_rank = replica_rank
 -        self.config: RolloutConfig = omega_conf_to_dataclass(config)
 +        if is_torch_npu_available(check_device=False):
@@ -349,26 +290,18 @@ index c01cdd79126ffa51ddcb42cdc3ff6529d5c6ecbe..70adbd90b887e6e1d860209fe27d0401
 +        else:
 +            self.config: RolloutConfig = omega_conf_to_dataclass(config)
          self.model_config: HFModelConfig = model_config
- 
-         self.world_size = (
 diff --git a/verl/workers/rollout/utils.py b/verl/workers/rollout/utils.py
-index 28d426dda165ac8597d0f3d452496fffd63bba14..5f7db040f36384fc3bba7340e4d4b5ba2a941525 100644
+index 06a1daef..890ee656 100644
 --- a/verl/workers/rollout/utils.py
 +++ b/verl/workers/rollout/utils.py
-@@ -12,8 +12,10 @@
- # See the License for the specific language governing permissions and
- # limitations under the License.
+@@ -14,4 +14,6 @@
  import asyncio
 +import hashlib
  import logging
  import os
 +from typing import Any
  
- import numpy as np
- import ray
-@@ -26,6 +28,69 @@ from verl.workers.config.rollout import PrometheusConfig
- logger = logging.getLogger(__file__)
- logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
+@@ -29,2 +31,65 @@ logger.setLevel(os.getenv("VERL_LOGGING_LEVEL", "WARN"))
  
 +_SAMPLING_EPS = 1e-5
 +
@@ -434,23 +367,15 @@ index 28d426dda165ac8597d0f3d452496fffd63bba14..5f7db040f36384fc3bba7340e4d4b5ba
 +    )
 +
  
- def get_max_position_embeddings(hf_config) -> int:
-     max_len = getattr(hf_config, "max_position_embeddings", None)
 diff --git a/verl/workers/rollout/vllm_rollout/vllm_async_server.py b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
-index 1a4def4fd8cce9abdfc00b5212aff7a70d645ea6..c19293ad16ea9c8d0615d0a59e6ef3454a1cf34c 100644
+index 6d8773a6..4dd8ef91 100644
 --- a/verl/workers/rollout/vllm_rollout/vllm_async_server.py
 +++ b/verl/workers/rollout/vllm_rollout/vllm_async_server.py
-@@ -43,6 +43,7 @@ from verl.utils.profiler import DistProfiler, build_vllm_profiler_args
- from verl.utils.tokenizer import normalize_token_ids
- from verl.utils.vllm.vllm_fp8_utils import apply_vllm_fp8_patches
+@@ -46,2 +46,3 @@ from verl.utils.vllm.vllm_fp8_utils import apply_vllm_fp8_patches
  from verl.workers.config import HFModelConfig, RolloutConfig
 +from verl.workers.config.rollout import ensure_rollout_config
  from verl.workers.rollout.replica import RolloutMode, RolloutReplica, TokenOutput
- from verl.workers.rollout.utils import get_max_position_embeddings, qwen2_5_vl_dedup_image_tokens, run_uvicorn
- from verl.workers.rollout.vllm_rollout.utils import (
-@@ -349,14 +350,29 @@ class vLLMHttpServer:
-             )
- 
+@@ -357,10 +358,25 @@ class vLLMHttpServer:
          if self.config.data_parallel_size > 1:
 -            assert self.gpus_per_node % self.config.tensor_model_parallel_size == 0, (
 -                "gpus_per_node should be divisible by tensor_model_parallel_size"
@@ -484,22 +409,13 @@ index 1a4def4fd8cce9abdfc00b5212aff7a70d645ea6..c19293ad16ea9c8d0615d0a59e6ef345
 +                    f"({self.config.tensor_model_parallel_size})"
 +                )
              dp_args = {
-                 "data_parallel_size": self.config.data_parallel_size,
-                 "data_parallel_size_local": data_parallel_size_local,
-@@ -583,6 +599,6 @@ class vLLMHttpServer:
-         sampling_params["logprobs"] = 0 if sampling_params.pop("logprobs", False) else None
-         sampling_params.setdefault("repetition_penalty", self.config.get("repetition_penalty", 1.0))
+@@ -597,3 +613,3 @@ class vLLMHttpServer:
          sampling_params.setdefault("ignore_eos", self.config.get("ignore_eos", False))
 -        # Inject per-request seed for deterministic sampling when full_determinism is enabled.
 +        # full_determinism supplies a fallback seed; per_request_seed may set one upstream.
          if self.config.full_determinism:
-             sampling_params.setdefault("seed", self.replica_rank + self.config.seed)
-@@ -983,6 +999,8 @@ class vLLMHttpServer:
- 
-     def _init_config(self, config):
+@@ -998,2 +1014,4 @@ class vLLMHttpServer:
          """Initialise config. Override when a specific dataclass_type is needed."""
 +        if is_torch_npu_available(check_device=False):
 +            return ensure_rollout_config(config)
          return omega_conf_to_dataclass(config)
- 
-     def _init_model_config(self, model_config):


### PR DESCRIPTION
## Summary

- Refresh `verl_npu_pp_per_request_seed_main.patch` for verl `6f2aa24a` (`0.9.0.dev`).
- Update import/context hunks in `llm_server.py` and `vllm_async_server.py`.
- Keep the main seed-only fallback unchanged and apply-clean.
- Keep MindSpeed skipped because its marker is already upstream.

## Drift provenance

- First breaking commit: `42adda39` — [rollout, vllm] fix: stop the policy from sampling vision placeholder tokens (#7038).
- Later context drift: `5b2bfe7c` — feat: verl add rl insight (#6680).

## Validation

- Combined main patch: apply, reverse-check, and reverse-apply passed in a clean LF worktree.
- Main seed-only fallback: apply, reverse-check, and reverse-apply passed.
- Recipe diff whitespace check passed.

## Scope

Only updates `true_on_policy/patch/verl_patches/verl_npu_pp_per_request_seed_main.patch`.