### PR TITLE
Update baseline

### DIFF
--- a/baseline/a2/nightly_log/run_qwen3_vl_8b_Instruct_fsdp2_npu/baseline_qwen3_vl_8b_Instruct_fsdp2_npu.txt
+++ b/baseline/a2/nightly_log/run_qwen3_vl_8b_Instruct_fsdp2_npu/baseline_qwen3_vl_8b_Instruct_fsdp2_npu.txt
@@ -1,5 +1,5 @@
-actor/perf/max_memory_allocated_gb:39.2972
-timing_s/step:410.0572
-perf/throughput:87.646
-critic/rewards/mean:-0.8556
-training/rollout_probs_diff_mean:0.0237
+actor/perf/max_memory_allocated_gb:45.43
+timing_s/step:87.84
+perf/throughput:164.24
+critic/rewards/mean:0.384750
+training/rollout_probs_diff_mean:0.005523

--- a/baseline/a3/nightly_log/run_gspo_qwen3_30b_megatron_npu/baseline_gspo_qwen3_30b_megatron_npu.txt
+++ b/baseline/a3/nightly_log/run_gspo_qwen3_30b_megatron_npu/baseline_gspo_qwen3_30b_megatron_npu.txt
@@ -1,5 +1,5 @@
 actor/perf/max_memory_allocated_gb:49.135295
-timing_s/step:102.221900
-perf/throughput:29.115384
+timing_s/step:90.368034
+perf/throughput:32.056511
 critic/rewards/mean:0.937500
 training/rollout_probs_diff_mean:0.005604


### PR DESCRIPTION
1. Update baselines for nightlyCI_gspo-qwen3-30b-megatron-vllm_ascend and nightlyCI_grpo_qwen3_vl_8b_Instruct_fsdp2_vllm_ascend
2. `actor/perf/max_memory_allocated_gb` increased, due to https://github.com/verl-project/verl/pull/6935 (4.5GB) and https://github.com/verl-project/verl/pull/7347 (1GB)