### PR TITLE
Update baseline for nightlyCI_gspo-qwen3-8b-fsdp2-vllm_ascend

### DIFF
--- a/baseline/a2/nightly_log/run_gspo_qwen3_8b_fsdp2_npu/baseline_gspo_qwen3_8b_fsdp2_npu.txt
+++ b/baseline/a2/nightly_log/run_gspo_qwen3_8b_fsdp2_npu/baseline_gspo_qwen3_8b_fsdp2_npu.txt
@@ -1,5 +1,5 @@
-actor/perf/max_memory_allocated_gb:41.884435
-timing_s/step:79.947007
-perf/throughput:127.9929
+actor/perf/max_memory_allocated_gb:47.866173
+timing_s/step:83.027817
+perf/throughput:247.402200
 critic/rewards/mean:0.3998047
 training/rollout_probs_diff_mean:0.0045346


### PR DESCRIPTION
1. actor/perf/max_memory_allocated_gb increased, due to https://github.com/verl-project/verl/pull/6935 (4.5GB) and https://github.com/verl-project/verl/pull/7347 (1GB)
2. Regenerate perf metrics after A2 cluster migration. New baseline is generated from the latest 5 nightly runs.