### PR TITLE
update baseline for nightlyCI_gspo-qwen3-8b-fsdp2-vllm_ascend

### DIFF
--- a/baseline/a2/nightly_log/run_gspo_qwen3_8b_fsdp2_npu/baseline_gspo_qwen3_8b_fsdp2_npu.txt
+++ b/baseline/a2/nightly_log/run_gspo_qwen3_8b_fsdp2_npu/baseline_gspo_qwen3_8b_fsdp2_npu.txt
@@ -1,4 +1,4 @@
-actor/perf/max_memory_allocated_gb:47.866173
+actor/perf/max_memory_allocated_gb:20.825053
 timing_s/step:83.027817
 perf/throughput:247.402200
 critic/rewards/mean:0.3998047


### PR DESCRIPTION
[verl PR #7458](https://github.com/verl-project/verl/pull/7458) set `use_no_sync_for_gradient_accumulation` to False for this test case, which greatly reduced the memory footprint. Update baseline to reflect this change.