### PR TITLE
fix(rollout_elastic): harden FT path against store/node faults and partial batches

### DIFF
--- a/rollout_elastic/patch/experimental.py
+++ b/rollout_elastic/patch/experimental.py
@@ -415,8 +415,8 @@ async def _one_step_async_gen_next_batch(self, continuous_iterator):
     import torch
 
     from verl.protocol import DataProto
+    from verl.trainer.ppo.ray_trainer import compute_response_mask
     from verl.utils.debug import marked_timer
-    from verl.utils.model import compute_response_mask
 
     try:
         epoch, batch_dict = next(continuous_iterator)
@@ -569,6 +569,9 @@ async def _one_step_fit_step(self, batch_data_future, continuous_iterator):
 
     def pad_batch_to_size(batch, target_size):
         current_size = len(batch)
+        if current_size == 0:
+            print("Warning: empty batch returned from generation; skipping padding")
+            return batch
         if current_size == target_size:
             return batch
         elif current_size > target_size:

--- a/rollout_elastic/patch/llm_server.py
+++ b/rollout_elastic/patch/llm_server.py
@@ -118,6 +118,12 @@ def mark_failed(self, server_id: str) -> None:
     _lb_core(self).mark_failed(server_id)
 
 
+@add(GlobalRequestLoadBalancer, "set_fault_tolerance")
+def set_fault_tolerance(self, enabled: bool) -> None:
+    """Enable or disable fault tolerance for the load balancer."""
+    _lb_core(self)._ft = bool(enabled)
+
+
 @patch(GlobalRequestLoadBalancer, "add_servers")
 def add_servers(self, servers: dict[str, ray.actor.ActorHandle]) -> None:
     """Add new servers to the server handles. Idempotent; resurrects dead ids."""
@@ -450,31 +456,51 @@ async def _fully_generate(
         checkpoint = None
         progress_ctx = None
         if progress_on:
-            from verl.workers.rollout.fault_tolerance import ProgressContext, VLLMProgressCheckPoint
-
-            result = await VLLMProgressCheckPoint.create_or_resume(
-                store=self._progress_store,
-                run_id=self._run_id,
-                recovery_id=recovery_id,
-                prompt_token_ids=original_prompt,
-                sampling_params=original_sampling,
-                model_weight_version=model_weight_version,
-                flush_token_interval=self._flush_token_interval(),
-                model_version_policy=self._model_version_policy(),
+            from verl.workers.rollout.fault_tolerance import (
+                ProgressContext,
+                VLLMProgressCheckPoint,
+                is_transient_fault,
             )
-            checkpoint = result.checkpoint
-            progress_ctx = ProgressContext(checkpoint=checkpoint)
-            prefix_for_call = checkpoint.resume_prefix_token_ids()
-            call_sampling = copy.deepcopy(original_sampling)
-            if limit_key is not None:
-                call_sampling[limit_key] = checkpoint.remaining_max_tokens()
-            if checkpoint.inherited_prefix_len > 0:
-                final_output = TokenOutput(
-                    token_ids=list(checkpoint.cumulative_token_ids),
-                    log_probs=list(checkpoint.cumulative_log_probs) if checkpoint.cumulative_log_probs else [],
-                    routed_experts=checkpoint.cumulative_routed_experts,
-                    num_preempted=checkpoint.num_preempted,
+
+            try:
+                result = await VLLMProgressCheckPoint.create_or_resume(
+                    store=self._progress_store,
+                    run_id=self._run_id,
+                    recovery_id=recovery_id,
+                    prompt_token_ids=original_prompt,
+                    sampling_params=original_sampling,
+                    model_weight_version=model_weight_version,
+                    flush_token_interval=self._flush_token_interval(),
+                    model_version_policy=self._model_version_policy(),
                 )
+            except Exception as e:
+                if not is_transient_fault(e):
+                    raise
+                print(
+                    f"FullyLLMServerClient: progress store unavailable"
+                    f"({type(e).__name__}), degrading to fresh attempt"
+                    f"(run={self._run_id}, recovery_id={recovery_id})",
+                    flush=True,
+                )
+                prefix_for_call = original_prompt
+                call_sampling = sampling_params
+            else:
+                checkpoint = result.checkpoint
+                progress_ctx = ProgressContext(checkpoint=checkpoint)
+                prefix_for_call = checkpoint.resume_prefix_token_ids()
+                call_sampling = copy.deepcopy(original_sampling)
+                if limit_key is not None:
+                    call_sampling[limit_key] = checkpoint.remaining_max_tokens()
+                # Seed final_output with inherited cumulative so that after fault reset
+                # (where final_output was cleared) the persisted tokens are not lost.
+                # On the abort path this is idempotent (cumulative == existing final_output).
+                if checkpoint.inherited_prefix_len > 0:
+                    final_output = TokenOutput(
+                        token_ids=list(checkpoint.cumulative_token_ids),
+                        log_probs=list(checkpoint.cumulative_log_probs) if checkpoint.cumulative_log_probs else [],
+                        routed_experts=checkpoint.cumulative_routed_experts,
+                        num_preempted=checkpoint.num_preempted,
+                    )
         else:
             progress_ctx = None
             prefix_for_call = original_prompt + final_output.token_ids
@@ -612,9 +638,19 @@ def _resolve_max_model_len(self) -> Optional[int]:
 @add(LLMServerManager, "_init_progress_store")
 async def _init_progress_store(self, progress_cfg) -> None:
     """Mode C: create and initialise the StoreActor. Called during FT assembly."""
+    from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
+
     from verl.workers.rollout.fault_tolerance import RolloutProgressStoreActor
 
-    self._progress_store = RolloutProgressStoreActor.remote()
+    try:
+        node_id = ray.get_runtime_context().get_node_id()
+        scheduling_strategy = NodeAffinitySchedulingStrategy(node_id=node_id, soft=True)
+    except Exception:
+        scheduling_strategy = None
+    options = {"max_restarts": 3, "max_task_retries": 3}
+    if scheduling_strategy is not None:
+        options["scheduling_strategy"] = scheduling_strategy
+    self._progress_store = RolloutProgressStoreActor.options(**options).remote()
     await self._progress_store.init.remote(progress_cfg)
 
 
@@ -628,8 +664,9 @@ async def _init_global_load_balancer(self) -> None:
     self.global_load_balancer = GlobalRequestLoadBalancer.remote(
         servers=dict(zip(self.server_addresses, self.server_handles, strict=True)),
         max_cache_size=DEFAULT_ROUTING_CACHE_SIZE,
-        enable_fault_tolerance=ft_on,
     )
+    if ft_on:
+        await self.global_load_balancer.set_fault_tolerance.remote(True)
 
 
 @patch(LLMServerManager, "get_client")

--- a/rollout_elastic/workers/rollout/fault_tolerance/batch.py
+++ b/rollout_elastic/workers/rollout/fault_tolerance/batch.py
@@ -30,6 +30,7 @@ from verl.workers.rollout.fault_tolerance.exceptions import (
     AllServersFailed,
     BatchMostlyFailed,
     ServerUnavailable,
+    is_transient_fault,
 )
 
 # Prompt-level fault exceptions that L4 should absorb into the partial batch.
@@ -61,6 +62,9 @@ def filter_partial_batch(
     fault_count = 0
     for i, r in enumerate(results):
         if isinstance(r, _PROMPT_FAULT_TYPES):
+            fault_count += 1
+            continue
+        if is_transient_fault(r):
             fault_count += 1
             continue
         if isinstance(r, BaseException):

--- a/rollout_elastic/workers/rollout/fault_tolerance/progress/progress_store_actor.py
+++ b/rollout_elastic/workers/rollout/fault_tolerance/progress/progress_store_actor.py
@@ -29,24 +29,32 @@ from verl.workers.rollout.fault_tolerance.progress.types import (
 class RolloutProgressStoreActor:
     def __init__(self) -> None:
         self._core: RolloutProgressStore | None = None
+        self._config: ProgressConfig | None = None
 
-    def _get_core(self) -> RolloutProgressStore:
+    async def _get_core(self) -> RolloutProgressStore:
         if self._core is None:
-            raise RuntimeError("RolloutProgressStoreActor.init() must be called first")
+            if self._config is None:
+                raise RuntimeError("RolloutProgressStoreActor.init() must be called first")
+            self._core = RolloutProgressStore(self._config)
+            await self._core.init(self._config)
         return self._core
 
     async def init(self, config: ProgressConfig) -> None:
+        self._config = config
         self._core = RolloutProgressStore(config)
         await self._core.init(config)
 
-    def preflight_dir(self) -> None:
-        self._get_core().preflight_dir()
+    async def preflight_dir(self) -> None:
+        core = await self._get_core()
+        core.preflight_dir()
 
     async def shutdown(self) -> None:
-        await self._get_core().shutdown()
+        core = await self._get_core()
+        await core.shutdown()
 
     async def save(self, payload: CheckPointPayLoad) -> None:
-        await self._get_core().save(payload)
+        core = await self._get_core()
+        await core.save(payload)
 
     async def load_latest(
         self,
@@ -55,13 +63,17 @@ class RolloutProgressStoreActor:
         requested_model_version: str | None,
         policy: ModelVersionPolicy,
     ) -> LoadResult:
-        return await self._get_core().load_latest(run_id, recovery_id, requested_model_version, policy)
+        core = await self._get_core()
+        return await core.load_latest(run_id, recovery_id, requested_model_version, policy)
 
     async def mark_superseded(self, run_id: str, recovery_id: str, attempt_id: int) -> None:
-        await self._get_core().mark_superseded(run_id, recovery_id, attempt_id)
+        core = await self._get_core()
+        await core.mark_superseded(run_id, recovery_id, attempt_id)
 
     async def periodic_collect(self) -> GCStats:
-        return await self._get_core().periodic_collect()
+        core = await self._get_core()
+        return await core.periodic_collect()
 
     async def get_stats(self) -> dict:
-        return await self._get_core().get_stats()
+        core = await self._get_core()
+        return await core.get_stats()

--- a/rollout_elastic/workers/rollout/fault_tolerance/retry_client.py
+++ b/rollout_elastic/workers/rollout/fault_tolerance/retry_client.py
@@ -32,6 +32,7 @@ from omegaconf import DictConfig, OmegaConf
 
 from verl.utils.rollout_trace import rollout_trace_op
 from verl.utils.tokenizer import normalize_token_ids
+from verl.workers.rollout.fault_tolerance.exceptions import is_transient_fault
 from verl.workers.rollout.llm_server import LLMServerClient
 from verl.workers.rollout.replica import TokenOutput
 
@@ -163,33 +164,44 @@ class RetryLLMServerClient(LLMServerClient):
             if progress_on:
                 sp_for_checkpoint = dict(original_sampling)
                 sp_for_checkpoint["max_tokens"] = self._resolve_original_max_tokens(original_sampling, original_prompt)
-                result = await VLLMProgressCheckPoint.create_or_resume(
-                    store=self._progress_store,
-                    run_id=self._run_id,
-                    recovery_id=recovery_id,
-                    prompt_token_ids=original_prompt,
-                    sampling_params=sp_for_checkpoint,
-                    model_weight_version=await self._weights_version(),
-                    flush_token_interval=self._flush_token_interval(),
-                    model_version_policy=self._model_version_policy(),
-                )
-                checkpoint = result.checkpoint
-                progress_ctx = ProgressContext(checkpoint=checkpoint)
-                prefix_for_call = checkpoint.resume_prefix_token_ids()
-                call_sampling = copy.deepcopy(original_sampling)
-                call_sampling["max_tokens"] = checkpoint.remaining_max_tokens()
-                logger.info(
-                    "[progress] run=%s, rid=%s, attempt=%d, outcome=%s, inherited_len=%d"
-                    "prefix_len=%d remaining_max_tokens=%d (%s)",
-                    self._run_id,
-                    recovery_id,
-                    result.attempt_id,
-                    result.outcome.name,
-                    result.inherited_prefix_len,
-                    len(prefix_for_call),
-                    checkpoint.remaining_max_tokens(),
-                    result.failure_detail or "-",
-                )
+                try:
+                    result = await VLLMProgressCheckPoint.create_or_resume(
+                        store=self._progress_store,
+                        run_id=self._run_id,
+                        recovery_id=recovery_id,
+                        prompt_token_ids=original_prompt,
+                        sampling_params=sp_for_checkpoint,
+                        model_weight_version=await self._weights_version(),
+                        flush_token_interval=self._flush_token_interval(),
+                        model_version_policy=self._model_version_policy(),
+                    )
+                except Exception as e:
+                    if not is_transient_fault(e):
+                        raise
+                    print(
+                        f"RetryLLMServerClient: progress store unavailable"
+                        f"({type(e).__name__}), degrading to fresh attempt"
+                        f"(run={self._run_id}, recovery_id={recovery_id})",
+                        flush=True,
+                    )
+                else:
+                    checkpoint = result.checkpoint
+                    progress_ctx = ProgressContext(checkpoint=checkpoint)
+                    prefix_for_call = checkpoint.resume_prefix_token_ids()
+                    call_sampling = copy.deepcopy(original_sampling)
+                    call_sampling["max_tokens"] = checkpoint.remaining_max_tokens()
+                    logger.info(
+                        "[progress] run=%s, rid=%s, attempt=%d, outcome=%s, inherited_len=%d"
+                        "prefix_len=%d remaining_max_tokens=%d (%s)",
+                        self._run_id,
+                        recovery_id,
+                        result.attempt_id,
+                        result.outcome.name,
+                        result.inherited_prefix_len,
+                        len(prefix_for_call),
+                        checkpoint.remaining_max_tokens(),
+                        result.failure_detail or "-",
+                    )
             try:
                 output, server_id = await self._generate_once(
                     request_id,


### PR DESCRIPTION
- filter_partial_batch: absorb transient faults (Ray actor death, timeouts,connection errors) into the failure ratio instead of crashing the whole gather; non-transient exceptions still surface
- RetryLLMServerClient / FullyLLMServerClient: degrade to a fresh attempt when the progress store is unavailable due to a transient fault, instead of failing the request
- RolloutProgressStoreActor: make _get_core async with lazy re-init from the cached config so the store recovers without an explicit init() call; preflight_dir becomes async accordingly
- pad_batch_to_size: skip padding on an empty generation result instead of raising ZeroDivisionError
- fix compute_response_mask import for verl@dfc01f85 (it lives in verl.trainer.ppo.ray_trainer, not verl.utils.model)
- GlobalRequestLoadBalancer: add set_fault_tolerance and enable it after actor construction instead of passing enable_fault_tolerance through remote() kwargs