### PR TITLE
feat: add SAPO Megatron NPU training recipe for Qwen3.5-4B

### DIFF
--- a/sapo/README.md
+++ b/sapo/README.md
@@ -1,0 +1,373 @@
+# Recipe: Smooth Advantage PO (SAPO)
+
+## Required `verl` version
+
+See [`REQUIRED_VERL.txt`](REQUIRED_VERL.txt) for the upstream repository, install mode, and copy-pastable `pip` / `git` instructions.
+
+📝 **Paper@arXiv**: [SAPO: Smooth Advantage PO](https://arxiv.org/abs/2511.20347)
+
+> SAPO replaces ratio clipping with a smooth tau-parameterized surrogate. Through asymmetric gating (`tau_pos` / `tau_neg`), it applies different degrees of regularization to positive and negative advantages, mitigating entropy collapse and improving training stability in long-CoT RL scenarios.
+
+## Quickstart
+
+1. Prepare the datasets:
+
+```bash
+# Download DAPO-Math-17k training dataset
+git clone https://huggingface.co/datasets/BytedTsinghua-SIA/DAPO-Math-17k \
+    $HOME/verl/datasets/dapo-math-17k
+
+# Download AIME 2024 test dataset
+git clone https://huggingface.co/datasets/Maxwell-Jia/AIME_2024 \
+    $HOME/verl/datasets/aime-2024
+```
+
+2. Download model weights:
+
+```bash
+hf download Qwen/Qwen3.5-4B --local-dir $HOME/verl/models/Qwen3.5-4B
+```
+
+3. Start Ray cluster and launch training:
+
+```bash
+# Head node
+ray start --head --port 6766 --resources='{"NPU": 16}'
+ray status
+
+# Worker nodes (remaining 7 nodes for 8-node config)
+ray start --address=<head_ip>:6766 --resources='{"NPU": 16}'
+
+# Launch SAPO training
+bash sapo/run_qwen3_5_4b_megatron_npu.sh
+```
+
+Override defaults via env vars:
+
+```bash
+MODEL_PATH=/path/to/Qwen3.5-4B \
+TRAIN_FILE=/path/to/train.parquet \
+VAL_FILE=/path/to/val.parquet \
+TP=4 PP=2 \
+bash sapo/run_qwen3_5_4b_megatron_npu.sh
+```
+
+## Scripts
+
+| Script | Model | Backend | Algorithm | Hardware |
+|---|---|---|---|---|
+| `run_qwen3_5_4b_megatron_npu.sh` | Qwen3.5-4B (dense, GDN) | Megatron + vLLM | SAPO | 8 nodes × 16 NPUs (Atlas 800T A3) |
+
+## Algorithm Configuration
+
+```bash
+# Core algorithm
+algorithm.adv_estimator=grpo                  # GRPO advantage estimation
+algorithm.use_kl_in_reward=False             # No KL penalty in reward
+
+# SAPO policy loss
+actor_rollout_ref.actor.policy_loss.loss_mode=sapo
++actor_rollout_ref.actor.policy_loss.tau_pos=1.0   # Positive advantage gate
++actor_rollout_ref.actor.policy_loss.tau_neg=1.05  # Negative advantage gate (slightly larger, more conservative)
+
+# KL config (SAPO does not use KL loss)
+actor_rollout_ref.actor.use_kl_loss=False
+actor_rollout_ref.actor.entropy_coeff=0
+```
+
+Entry point: `verl.trainer.main_ppo` with `model_engine=megatron`.
+
+## Qwen3.5 Architecture Constraint (Critical)
+
+Qwen3.5 uses **Gated Delta Net (GDN)** linear attention, which currently does **NOT** support packed sequences (THD format) in Megatron-LM. The following three options must all be `False` to force **bshd** compute format:
+
+- `model.use_remove_padding=False` — disables padding removal at model level
+- `actor.megatron.use_remove_padding=False` — disables padding removal on Megatron actor side
+- `actor.use_dynamic_bsz=False` — required for bshd mode
+
+> Once Megatron-LM adds THD support for Qwen3.5 GDN, `use_remove_padding` can be set to `True` for better performance.
+
+## Environment
+
+### Software versions
+
+| software | version |
+|---|---|
+| Python | 3.11 |
+| CANN | ==9.0.0.B160 (CANN900B160) |
+| torch | ==2.9.0 |
+| torch_npu | ==2.9.0 |
+| triton_ascend | ==3.2.1 |
+| verl | main |
+| vllm | v0.18.0 |
+| vllm-ascend | v0.18.0 |
+| transformers | 5.3.0 |
+| Megatron-LM | 0.16.1 |
+| MindSpeed | 0.16.0 |
+| Megatron-Bridge | `de93536e` |
+
+### Megatron-Bridge installation
+
+> **Important**: The Docker image ships the deprecated `mbridge` (ISEEKYAN/mbridge, does not support Qwen3.5). You must manually install the official `Megatron-Bridge` (NVIDIA-NeMo/Megatron-Bridge, supports Qwen3.5). Both have the same import name `megatron_bridge`, making them easy to confuse.
+
+```bash
+# 1. Uninstall old version (avoid residual conflicts — same import name)
+pip uninstall -y megatron-bridge megatron_bridge mbridge || true
+
+# 2. Clone official repo and checkout the required commit
+git clone https://github.com/NVIDIA-NeMo/Megatron-Bridge.git /opt/megatron-bridge
+cd /opt/megatron-bridge
+git checkout de93536e
+
+# 3. Install in development mode
+pip install -e .
+
+# 4. Verify
+python -c "import megatron_bridge; print(megatron_bridge.__version__)"
+```
+
+**Three ways verl integrates Megatron-Core:**
+
+| Method | Status | Config |
+|---|---|---|
+| #1 verl built-in per-model conversion | Deprecated | `use_mbridge=False` (removed after v0.7) |
+| #2 mbridge (ISEEKYAN/mbridge) | Will be deprecated in v0.8, no new models accepted | `use_mbridge=True, vanilla_mbridge=True` |
+| #3 Megatron-Bridge (NVIDIA-NeMo official) | **Recommended**, supports Qwen3.5 | `use_mbridge=True, vanilla_mbridge=False` |
+
+This script uses method #3: `use_mbridge=True, vanilla_mbridge=False`.
+
+### Additional dependencies
+
+```bash
+pip install viztracer flash-linear-attention nvidia-modelopt nvidia-ml-py nvidia-resiliency-ext megatron-energon
+```
+
+- `flash-linear-attention` — Gated Delta Net (GDN) linear attention implementation, required for Qwen3.5.
+- `megatron-energon` — Megatron data loader.
+- `viztracer` — Performance tracing tool.
+
+## Hardware and Parallelism
+
+Default NPU configuration (8 nodes, 128 NPUs total), overridable via env vars:
+
+| model | nnodes | devices per node | TP | PP | CP | EP | ETP | GEN_TP | DP |
+|---|---|---|---|---|---|---|---|---|---|
+| Qwen3.5-4B | 8 | 16 | 4 | 2 | 1 | 1 | 1 | 4 | 16 |
+
+- **DP calculation**: `NNODES × NGPUS_PER_NODE / (TP × PP × CP) = 8 × 16 / (4×2×1) = 16`
+- **Constraint**: `train_batch_size >= DP` (at least 1 sample per DP rank), script uses `train_batch_size=512`
+- **GEN_TP=4**: vLLM rollout tensor parallelism, 4 NPUs per group, shares memory with Megatron (`gpu_memory_utilization=0.5`)
+
+Single-node example (1 node, 8 NPUs):
+
+| model | nnodes | devices per node | TP | PP | CP | EP | ETP | GEN_TP | DP |
+|---|---|---|---|---|---|---|---|---|---|
+| Qwen3.5-4B | 1 | 8 | 4 | 2 | 1 | 1 | 1 | 8 | 1 |
+
+## Key Training Parameters
+
+| Parameter | Value | Description |
+|---|---|---|
+| `train_batch_size` | 512 | Prompts per step |
+| `rollout.n` | 16 | Samples per prompt (GRPO group size) |
+| `ppo_mini_batch_size` | 32 | Mini-batch size |
+| `max_prompt_length` | 20480 | Prompt length limit |
+| `max_response_length` | 20480 | Response length limit |
+| `vllm.max_model_len` | 40960 | vLLM max sequence length |
+| `actor_lr` | 1e-6 | Actor learning rate |
+| `tau_pos` / `tau_neg` | 1.0 / 1.05 | SAPO asymmetric gating params |
+| `entropy_coeff` | 0 | Entropy regularization |
+| `use_kl_loss` | False | No KL in loss |
+| `use_kl_in_reward` | False | No KL in reward |
+| `adv_estimator` | grpo | Group-normalized advantage, no critic |
+| `loss_mode` | sapo | SAPO policy loss |
+| `total_epochs` | 32 | Total epochs |
+| `save_freq` | 5 | Save checkpoint every 5 steps |
+| `test_freq` | 1000 | Validate every 1000 steps |
+
+**Offload and precision** (`ALL_OFFLOAD=True`):
+
+| Parameter | Value |
+|---|---|
+| `param_offload` | True |
+| `optimizer_offload` | True |
+| `grad_offload` | True |
+| `optimizer_offload_fraction` | 1 |
+| `overlap_cpu_optimizer_d2h_h2d` | True |
+| `use_precision_aware_optimizer` | True |
+| `optimizer_cpu_offload` | True |
+| `dtype` | bfloat16 |
+
+**Transformer config overrides:**
+
+| Parameter | Value |
+|---|---|
+| `attention_backend` | auto |
+| `recompute_method` | uniform |
+| `recompute_granularity` | full |
+| `recompute_num_layers` | 1 |
+| `use_flash_attn` | True |
+| `use_naive_l2norm` | True |
+
+> ⚠️ `use_naive_l2norm=True` uses naive L2 norm instead of RMSNorm, which has weaker numerical stability at 20480 sequence length. If training crashes (NaN weights), investigate this option.
+
+## Training Flow
+
+```mermaid
+flowchart TD
+    A[Start Ray cluster] --> B[Load Qwen3.5-4B weights<br/>HF→Megatron via Megatron-Bridge]
+    B --> C[Initialize Megatron Actor/Ref<br/>TP=4 PP=2 CP=1]
+    C --> D[Initialize vLLM Rollout<br/>GEN_TP=4 gpu_mem_util=0.5]
+    D --> E{Training loop}
+    E --> F[Rollout: vLLM generates n=16 responses<br/>512×16=8192 per step]
+    F --> G[Compute reward<br/>use_kl_in_reward=False]
+    G --> H[Compute GRPO advantage<br/>adv_estimator=grpo]
+    H --> I[Actor forward: old_log_prob]
+    I --> J[Ref forward: ref_log_prob<br/>param_offload=True]
+    J --> K[SAPO loss<br/>tau_pos=1.0 tau_neg=1.05]
+    K --> L[Actor backward update]
+    L --> M{save_freq?}
+    M -->|yes| N[Save checkpoint]
+    M -->|no| E
+    N --> O[Sync weights to vLLM<br/>update_weights_bucket=4096MB]
+    O --> E
+    style F fill:#bbdefb,color:#0d47a1
+    style K fill:#c8e6c9,color:#1a5e20
+    style L fill:#fff3e0,color:#e65100
+```
+
+**Per-step data interaction sequence:**
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant T as Trainer (main_ppo)
+    participant DL as DataLoader
+    participant R as Rollout / vLLM
+    participant A as Actor / Megatron
+    participant REF as Ref / Megatron
+    participant RM as Reward Manager
+
+    T->>DL: Fetch batch (train_batch_size=512)
+    Note over DL: max_prompt_length=20480<br/>filter_overlong_prompts=True<br/>truncation='error'
+
+    T->>R: Send prompts
+    Note over R: rollout.n=16<br/>rollout.tensor_model_parallel_size=4<br/>gpu_memory_utilization=0.5<br/>vllm.max_model_len=40960
+    R-->>T: Return 512×16=8192 rollout sequences
+
+    T->>RM: Compute reward
+    Note over RM: use_kl_in_reward=False
+    RM-->>T: token-level reward
+
+    T->>A: Compute old_log_prob (rollout weights)
+    Note over A: ppo_micro_batch_size_per_gpu=1<br/>ppo_max_token_len_per_gpu=10240<br/>megatron: TP=4 PP=2 CP=1<br/>use_flash_attn=True
+    A-->>T: old_log_probs
+
+    T->>REF: Compute ref_log_prob (frozen weights)
+    Note over REF: ref.param_offload=True
+    REF-->>T: ref_log_probs
+
+    T->>T: Compute advantage
+    Note over T: adv_estimator=grpo (group-normalized, no critic)
+
+    T->>A: SAPO policy loss + backward update
+    Note over A: loss_mode=sapo<br/>tau_pos=1.0, tau_neg=1.05<br/>actor_lr=1e-6<br/>ppo_mini_batch_size=32
+    A-->>T: Updated weights
+
+    T->>R: Sync new weights to vLLM
+    Note over R: update_weights_bucket_megabytes=4096<br/>nccl_timeout=10800
+```
+
+## Troubleshooting
+
+### Q1: Missing Megatron-Bridge
+
+**Symptom**: Training fails with error "mbridge does not support Qwen3.5".
+
+**Root cause**: The Docker image ships `mbridge` (ISEEKYAN/mbridge, deprecated, only supports Qwen3/Qwen3-MoE, **not Qwen3.5**), not `Megatron-Bridge` (NVIDIA-NeMo official, supports Qwen3.5). verl falls back to the deprecated mbridge when the official package is not found.
+
+> Note: `mbridge` and `Megatron-Bridge` are **two different packages** — pip names `mbridge` vs `megatron-bridge`, both import as `megatron_bridge`, making them easy to confuse.
+
+**Solution**: Install official Megatron-Bridge manually, see [Megatron-Bridge installation](#megatron-bridge-installation) above.
+
+### Q2: mstx.range_end error
+
+**Symptom**: Training continues but each worker repeatedly prints:
+
+```
+[ERROR] Call range_end failed. Exception: mstx.range_end() missing 1 required positional argument: 'range_id'
+```
+
+**Root cause**: MindSpeed patches `torch.cuda.nvtx.range_push/pop` with NVTX→MSTX redirects, but `range_pop()` (0 args) is redirected to `mstx.range_end(range_id)` (1 required arg), causing TypeError.
+
+| Original API | Args | Patch target | Args | Compatible? |
+|---|---|---|---|---|
+| `nvtx.range_push(message)` | 1 required | `mstx.range_start(message, stream, domain)` | 1 required + 2 optional | ✅ |
+| `nvtx.range_pop()` | **0** | `mstx.range_end(range_id, domain)` | **1 required** | ❌ |
+
+**Solution**: Replace MindSpeed's two mstx patches with no-op wrappers:
+
+> ⚠️ **Do not simply comment out the patches.** Without patches, `torch.cuda.nvtx.range_push/pop` falls back to torch's stub, which raises `RuntimeError: NVTX functions not installed` on non-CUDA builds.
+
+```bash
+# Find the file inside the container
+REQUIREMENTS_FILE=$(python -c "import mindspeed.features_manager.megatron_basic.requirements_basic as m; print(m.__file__)")
+
+# Replace with no-op
+sed -i "s|pm.register_patch('torch.cuda.nvtx.range_push', torch_npu.npu.mstx.range_start)|pm.register_patch('torch.cuda.nvtx.range_push', lambda *a, **k: None)|" "$REQUIREMENTS_FILE"
+sed -i "s|pm.register_patch('torch.cuda.nvtx.range_pop', torch_npu.npu.mstx.range_end)|pm.register_patch('torch.cuda.nvtx.range_pop', lambda *a, **k: None)|" "$REQUIREMENTS_FILE"
+
+# Verify
+grep -n "nvtx" "$REQUIREMENTS_FILE"
+```
+
+### Q3: Checkpoint global shape mismatch
+
+**Symptom**: Training launch fails with:
+
+```
+megatron.core.dist_checkpointing.core.CheckpointingException: Global shape mismatch for
+loaded (torch.Size([1119331272])) and expected ((3362257868,)) tensor for key
+optimizer.distributed.dp_group_idx_7.gbuf_idx_0.dtype_(torch.bfloat16, torch.bfloat16)
+.bucket_idx_0.exp_avg
+```
+
+**Root cause**: The checkpoint directory contains a stale checkpoint from a different model size or parallelism config. verl auto-resumes from `default_local_dir`, and the old optimizer state doesn't match the new model. `actor.checkpoint.strict=False` **cannot bypass** this — `_validate_global_shapes` raises before the `strict` check.
+
+**Solution**: Remove or back up the old checkpoint directory before restarting:
+
+```bash
+# Option 1: Back up and remove old checkpoint
+mv $HOME/verl/ckpts/verl_sapo_qwen3_5/qwen3_5_4b_vllm_sapo_megatron \
+   $HOME/verl/ckpts/verl_sapo_qwen3_5/qwen3_5_4b_vllm_sapo_megatron.old
+
+# Option 2: Use a fresh output directory
+export CKPTS_DIR=$HOME/verl/ckpts/verl_sapo_qwen3_5/v2
+bash sapo/run_qwen3_5_4b_megatron_npu.sh
+```
+
+**Prevention**: When changing `MODEL_PATH` (different model size) or parallelism config (TP/PP/CP), always update the checkpoint directory to avoid cross-config resume.
+
+### Q4: Megatron→vLLM inference tokenizer error
+
+**Symptom**: After training, loading the merged checkpoint with vLLM for inference fails:
+
+```
+ValueError: Tokenizer class TokenizersBackend does not exist or is not currently imported.
+```
+
+**Root cause**: **transformers major version incompatibility** (training 5.x → inference 4.x). verl's model merger saves the tokenizer via `tokenizer.save_pretrained()` inside the training image. transformers 5.x writes `"tokenizer_class": "TokenizersBackend"` (a new unified backend class in 5.x) into `tokenizer_config.json`. The inference image's transformers 4.57.x doesn't have `TokenizersBackend`, so vLLM's `AutoTokenizer.from_pretrained()` fails.
+
+**Solution**: **Upgrade the inference image's transformers to 5.x**:
+
+```bash
+pip install transformers==5.3.0
+```
+
+**Prevention**: Training and inference should use the same transformers major version. If the training and inference images have different major versions, the saved tokenizer files need to be overwritten with the original model's tokenizer or have the `tokenizer_class` field fixed before inference.
+
+## Notes
+
+- The script auto-detects NPU environment via `torch_npu`.
+- Qwen3.5 GDN does not use packed sequences, so `use_remove_padding=False` and `use_dynamic_bsz=False` are required.
+- NPU branch sets `vanilla_mbridge=False`, `use_flash_attn=True`, `use_naive_l2norm=True` for Ascend compatibility.

--- a/sapo/REQUIRED_VERL.txt
+++ b/sapo/REQUIRED_VERL.txt
@@ -1,0 +1,6 @@
+# SAPO — Smooth Advantage PO
+# Tracks verl main branch. Requires Ascend NPU hardware.
+UPSTREAM=https://github.com/verl-project/verl.git
+MODE=main
+PIP_INSTALL=pip install -e .
+NOTES=Tracks verl main branch. Requires Ascend NPU hardware (Atlas 800T A3 or Atlas 900 A3 SuperPoD). Additional dependencies: Megatron-LM==0.16.1, MindSpeed==0.16.0, Megatron-Bridge==de93536e, flash-linear-attention, megatron-energon.

--- a/sapo/run_qwen3_5_4b_megatron_npu.sh
+++ b/sapo/run_qwen3_5_4b_megatron_npu.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+# SAPO | text | vLLM rollout | Megatron training | Ascend NPU
+# SAPO (Smooth Advantage PO) replaces ratio clipping with a smooth tau-parameterized
+# surrogate (arXiv:2511.20347).
+#
+# Qwen3.5 architecture notes:
+#   Qwen3.5 uses Gated Delta Net (GDN) linear attention which currently does
+#   NOT support packed sequences (THD format) in Megatron-LM. Therefore:
+#     - model.use_remove_padding=False           (forces bshd compute format)
+#     - actor.megatron.use_remove_padding=False  (forces bshd compute format)
+#     - actor.use_dynamic_bsz=False              (required for bshd mode)
+#
+# Tested parallelism config (8 nodes, 16 NPUs/node, 128 NPUs total):
+#   TP=4 PP=2 CP=1 EP=1 ETP=1 GEN_TP=4  →  DP=16
+#
+# Requirements on Ascend:
+#   - Docker image: quay.io/ascend/verl:verl-9.0.0-a3-ubuntu22.04-py3.11-latest
+#   - Megatron-LM==0.16.1
+#   - MindSpeed==0.16.0
+#   - Megatron-Bridge==de93536e
+#   - pip install viztracer flash-linear-attention nvidia-modelopt nvidia-ml-py nvidia-resiliency-ext megatron-energon
+
+set -xeuo pipefail
+
+# This script runs on Ascend NPU only.
+python3 -c 'import torch_npu' 2>/dev/null || { echo "torch_npu not available. This script requires Ascend NPU." >&2; exit 1; }
+
+ulimit -n 32768
+export RAY_DEDUP_LOGS=0
+export HYDRA_FULL_ERROR=1
+export TASK_QUEUE_ENABLE=1
+export HCCL_EXEC_TIMEOUT=3600
+export HCCL_CONNECT_TIMEOUT=5400
+export HCCL_ASYNC_ERROR_HANDLING=0
+export HCCL_BUFFSIZE=300
+export CPU_AFFINITY_CONF=1
+export VLLM_USE_V1=1
+export VLLM_ASCEND_ENABLE_NZ=0
+export PYTORCH_NPU_ALLOC_CONF=garbage_collection_threshold:0.8
+export TOKENIZERS_PARALLELISM=false
+export CUDA_DEVICE_MAX_CONNECTIONS=1
+
+########################### Quick Config ###########################
+
+# ---- user-adjustable ----
+RAY_DATA_HOME=${RAY_DATA_HOME:-"${HOME}/verl"}
+MODEL_PATH=${MODEL_PATH:-"${RAY_DATA_HOME}/models/Qwen3.5-4B"}
+TRAIN_FILE=${TRAIN_FILE:-"${RAY_DATA_HOME}/datasets/dapo-math-17k/train.parquet"}
+VAL_FILE=${VAL_FILE:-"${RAY_DATA_HOME}/datasets/aime-2024/test.parquet"}
+CKPTS_DIR=${CKPTS_DIR:-"${RAY_DATA_HOME}/ckpts/${PROJECT_NAME:-verl_sapo_qwen3_5}/${EXPERIMENT_NAME:-qwen3_5_4b_vllm_sapo_megatron}"}
+ROLLOUTS_DIR=${ROLLOUTS_DIR:-"${RAY_DATA_HOME}/rollouts/${PROJECT_NAME:-verl_sapo_qwen3_5}/${EXPERIMENT_NAME:-qwen3_5_4b_vllm_sapo_megatron}"}
+
+NNODES=${NNODES:-8}
+NGPUS_PER_NODE=${NGPUS_PER_NODE:-16}
+
+TP=${TP:-4}
+PP=${PP:-2}
+CP=${CP:-1}
+EP=${EP:-1}
+ETP=${ETP:-1}
+GEN_TP=${GEN_TP:-4}
+ACTOR_VPP=${ACTOR_VPP:-null}
+ALL_OFFLOAD=${ALL_OFFLOAD:-True}
+
+tau_pos=${TAU_POS:-1.0}
+tau_neg=${TAU_NEG:-1.05}
+
+actor_lr=${ACTOR_LR:-1e-6}
+entropy_coeff=${ENTROPY_COEFF:-0}
+
+# DP = NNODES * NGPUS_PER_NODE / (TP * PP * CP)
+train_batch_size=${TRAIN_BATCH_SIZE:-512}
+ppo_mini_batch_size=${PPO_MINI_BATCH_SIZE:-32}
+max_prompt_length=${MAX_PROMPT_LENGTH:-20480}
+max_response_length=${MAX_RESPONSE_LENGTH:-20480}
+ppo_max_token_len_per_gpu=${PPO_MAX_TOKEN_LEN_PER_GPU:-10240}
+rollout_n=${ROLLOUT_N:-16}
+rollout_gpu_mem_util=${ROLLOUT_GPU_MEM_UTIL:-0.5}
+vllm_max_model_len=${VLLM_MAX_MODEL_LEN:-40960}
+
+total_epochs=${TOTAL_EPOCHS:-32}
+save_freq=${SAVE_FREQ:-5}
+test_freq=${TEST_FREQ:-1000}
+
+project_name=${PROJECT_NAME:-verl_sapo_qwen3_5}
+experiment_name=${EXPERIMENT_NAME:-qwen3_5_4b_vllm_sapo_megatron}
+
+use_dynamic_bsz=False
+use_remove_padding=False
+update_weights_bucket_megabytes=${UPDATE_WEIGHTS_BUCKET_MEGABYTES:-4096}
+# ---- end user-adjustable ----
+
+########################### Parameter Arrays ###########################
+
+DATA=(
+    data.train_files="['$TRAIN_FILE']"
+    data.val_files="['$VAL_FILE']"
+    data.train_batch_size=${train_batch_size}
+    data.max_prompt_length=${max_prompt_length}
+    data.max_response_length=${max_response_length}
+    data.truncation='error'
+    data.filter_overlong_prompts=True
+)
+
+MODEL=(
+    actor_rollout_ref.model.path="$MODEL_PATH"
+    actor_rollout_ref.model.trust_remote_code=True
+    actor_rollout_ref.model.use_remove_padding=${use_remove_padding}
+)
+
+ACTOR=(
+    actor_rollout_ref.actor.policy_loss.loss_mode=sapo
+    +actor_rollout_ref.actor.policy_loss.tau_pos=${tau_pos}
+    +actor_rollout_ref.actor.policy_loss.tau_neg=${tau_neg}
+    actor_rollout_ref.actor.optim.lr=${actor_lr}
+    actor_rollout_ref.actor.ppo_mini_batch_size=${ppo_mini_batch_size}
+    actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=1
+    actor_rollout_ref.actor.ppo_max_token_len_per_gpu=${ppo_max_token_len_per_gpu}
+    actor_rollout_ref.actor.use_dynamic_bsz=${use_dynamic_bsz}
+    actor_rollout_ref.actor.use_kl_loss=False
+    actor_rollout_ref.actor.entropy_coeff=${entropy_coeff}
+    actor_rollout_ref.actor.megatron.use_mbridge=True
+    actor_rollout_ref.actor.megatron.vanilla_mbridge=False
+    actor_rollout_ref.actor.megatron.use_remove_padding=False
+    actor_rollout_ref.actor.megatron.tensor_model_parallel_size=${TP}
+    actor_rollout_ref.actor.megatron.pipeline_model_parallel_size=${PP}
+    actor_rollout_ref.actor.megatron.context_parallel_size=${CP}
+    actor_rollout_ref.actor.megatron.expert_model_parallel_size=${EP}
+    actor_rollout_ref.actor.megatron.expert_tensor_parallel_size=${ETP}
+    actor_rollout_ref.actor.megatron.virtual_pipeline_model_parallel_size=${ACTOR_VPP}
+    actor_rollout_ref.actor.megatron.param_offload=${ALL_OFFLOAD}
+    actor_rollout_ref.actor.megatron.optimizer_offload=${ALL_OFFLOAD}
+    actor_rollout_ref.actor.megatron.grad_offload=${ALL_OFFLOAD}
+    actor_rollout_ref.actor.megatron.dtype=bfloat16
+    ++actor_rollout_ref.actor.megatron.override_transformer_config.attention_backend=auto
+    +actor_rollout_ref.actor.megatron.override_transformer_config.recompute_method=uniform
+    +actor_rollout_ref.actor.megatron.override_transformer_config.recompute_granularity=full
+    +actor_rollout_ref.actor.megatron.override_transformer_config.recompute_num_layers=1
+    +actor_rollout_ref.actor.optim.override_optimizer_config.optimizer_offload_fraction=1
+    +actor_rollout_ref.actor.optim.override_optimizer_config.overlap_cpu_optimizer_d2h_h2d=True
+    +actor_rollout_ref.actor.optim.override_optimizer_config.use_precision_aware_optimizer=True
+    +actor_rollout_ref.actor.optim.override_optimizer_config.optimizer_cpu_offload=True
+)
+
+ROLLOUT=(
+    actor_rollout_ref.rollout.name=vllm
+    actor_rollout_ref.rollout.tensor_model_parallel_size=${GEN_TP}
+    actor_rollout_ref.rollout.gpu_memory_utilization=${rollout_gpu_mem_util}
+    actor_rollout_ref.rollout.n=${rollout_n}
+    actor_rollout_ref.rollout.dtype=bfloat16
+    actor_rollout_ref.rollout.log_prob_use_dynamic_bsz=${use_dynamic_bsz}
+    actor_rollout_ref.rollout.log_prob_max_token_len_per_gpu=${ppo_max_token_len_per_gpu}
+    actor_rollout_ref.rollout.log_prob_micro_batch_size_per_gpu=1
+    actor_rollout_ref.rollout.checkpoint_engine.update_weights_bucket_megabytes=${update_weights_bucket_megabytes}
+    +actor_rollout_ref.rollout.engine_kwargs.vllm.max_model_len=${vllm_max_model_len}
+)
+
+REF=(
+    actor_rollout_ref.ref.log_prob_micro_batch_size_per_gpu=1
+    actor_rollout_ref.ref.log_prob_use_dynamic_bsz=${use_dynamic_bsz}
+    actor_rollout_ref.ref.log_prob_max_token_len_per_gpu=${ppo_max_token_len_per_gpu}
+    actor_rollout_ref.ref.megatron.tensor_model_parallel_size=${TP}
+    actor_rollout_ref.ref.megatron.pipeline_model_parallel_size=${PP}
+    actor_rollout_ref.ref.megatron.context_parallel_size=${CP}
+    actor_rollout_ref.ref.megatron.expert_model_parallel_size=${EP}
+    actor_rollout_ref.ref.megatron.expert_tensor_parallel_size=${ETP}
+    actor_rollout_ref.ref.megatron.param_offload=${ALL_OFFLOAD}
+)
+
+ALGORITHM=(
+    algorithm.adv_estimator=grpo
+    algorithm.use_kl_in_reward=False
+)
+
+TRAINER=(
+    trainer.balance_batch=True
+    trainer.critic_warmup=0
+    trainer.logger='["console"]'
+    trainer.project_name=${project_name}
+    trainer.experiment_name=${experiment_name}
+    trainer.n_gpus_per_node=${NGPUS_PER_NODE}
+    trainer.nnodes=${NNODES}
+    trainer.save_freq=${save_freq}
+    trainer.val_before_train=False
+    trainer.test_freq=${test_freq}
+    trainer.total_epochs=${total_epochs}
+    trainer.default_local_dir="${CKPTS_DIR}"
+    trainer.rollout_data_dir="${ROLLOUTS_DIR}"
+    trainer.device=npu
+)
+
+EXTRA=(
+    model_engine=megatron
+    actor_rollout_ref.nccl_timeout=10800
+    actor_rollout_ref.rollout.val_kwargs.n=1
+    actor_rollout_ref.rollout.val_kwargs.temperature=1.0
+    actor_rollout_ref.rollout.val_kwargs.top_p=0.7
+    actor_rollout_ref.actor.checkpoint.strict=False
+    +actor_rollout_ref.actor.megatron.override_transformer_config.use_flash_attn=True
+    +actor_rollout_ref.actor.megatron.override_transformer_config.use_naive_l2norm=True
+)
+
+########################### Launch ###########################
+
+echo "=============================="
+echo "Launching SAPO training on $NNODES nodes x $NGPUS_PER_NODE NPUs = $((NNODES * NGPUS_PER_NODE)) NPUs"
+echo "  TP=$TP PP=$PP CP=$CP EP=$EP ETP=$ETP GEN_TP=$GEN_TP"
+echo "  DP=$((NNODES * NGPUS_PER_NODE / (TP * PP * CP)))"
+echo "  train_batch_size=$train_batch_size, rollout.n=$rollout_n"
+echo "  MODEL_PATH=$MODEL_PATH"
+echo "=============================="
+
+mkdir -p logs
+
+PYTHONUNBUFFERED=1 python3 -m verl.trainer.main_ppo \
+    "${DATA[@]}" \
+    "${ALGORITHM[@]}" \
+    "${MODEL[@]}" \
+    "${ROLLOUT[@]}" \
+    "${ACTOR[@]}" \
+    "${REF[@]}" \
+    "${TRAINER[@]}" \
+    "${EXTRA[@]}" \
+    "$@" 2>&1 | tee logs/run_qwen3_5_4b_sapo_megatron_npu.log


### PR DESCRIPTION
## What does this PR do?

Adds the first **SAPO + Megatron** training recipe for **Ascend NPU**, targeting the **Qwen3.5-4B** dense model with Gated Delta Net (GDN) linear attention. Existing recipes cover GRPO (`grpo/`) and DAPO (`dapo/`) on NPU; this fills the SAPO gap.

Three files added under `sapo/`:

- `sapo/run_qwen3_5_4b_megatron_npu.sh` — Megatron backend + vLLM rollout, tested on 8 nodes × 16 NPUs (128 total) with TP=4 PP=2 CP=1 GEN_TP=4 (DP=16).
- `sapo/README.md` — Full deployment guide: environment setup, Megatron-Bridge installation (disambiguating `mbridge` vs `Megatron-Bridge`), mermaid flowchart + sequence diagram, and 4 troubleshooting Q&As.
- `sapo/REQUIRED_VERL.txt` — Tracks verl main branch.

## Context

A previous PR (https://github.com/verl-project/verl/pull/7801) submitted the same files to the main verl repo. Per collaborator feedback (@wucong25), the script and documentation are better suited for this repo.

## Tested configuration

| Item | Value |
|---|---|
| Model | Qwen3.5-4B (dense, GDN linear attention) |
| Algorithm | SAPO (`loss_mode=sapo`, `tau_pos=1.0`, `tau_neg=1.05`) |
| Backend | Megatron (via Megatron-Bridge `de93536e`) + vLLM rollout |
| Hardware | 8 nodes × 16 NPUs = 128 NPUs (Atlas 800T A3) |
| Parallelism | TP=4 PP=2 CP=1 EP=1 GEN_TP=4 → DP=16 |
| Dataset | DAPO-Math-17k |
| train_batch_size | 512, rollout.n=16 |

## Key design decisions

1. **GDN architecture constraint**: `use_remove_padding=False` + `use_dynamic_bsz=False` required — Qwen3.5 GDN does not support packed sequences (THD format) in Megatron-LM.
2. **Megatron-Bridge**: `use_mbridge=True, vanilla_mbridge=False` — uses official NVIDIA-NeMo/Megatron-Bridge (not the deprecated ISEEKYAN/mbridge that doesn't support Qwen3.5).
3. **Troubleshooting Q&As** from real deployment:
   - Q1: Missing Megatron-Bridge (Docker image ships deprecated `mbridge`)
   - Q2: `mstx.range_end` signature mismatch (MindSpeed NVTX→MSTX patch incompatibility)
   - Q3: Checkpoint global shape mismatch (stale checkpoint from different config)
   - Q4: Transformers 5.x tokenizer incompatibility (`TokenizersBackend` not found in 4.x)

## Checklist

- [x] Searched for similar PRs — no existing SAPO recipe in this repo.
- [x] `REQUIRED_VERL.txt` included with upstream URL and install mode.
- [x] `README.md` follows the format of existing recipes (e.g., `dapo/README.md`).
- [ ] Pre-commit checks (if configured in this repo).