### PR TITLE
fix(rollout_elastic): make LB patches effective across Ray workers

### DIFF
--- a/rollout_elastic/patch/_core.py
+++ b/rollout_elastic/patch/_core.py
@@ -86,7 +86,7 @@ def _register_actor_method(target: type, name: str, method: Callable) -> None:
     from ray._common.signature import extract_signature
 
     method_meta.methods[name] = method
-    method_meta.signatures[name] = extract_signature(method, ignores_first=True)
+    method_meta.signatures[name] = extract_signature(method, ignore_first=True)
     method_meta.decorators[name] = None
     method_meta.method_is_generator[name] = False
     method_meta.num_returns[name] = None

--- a/rollout_elastic/patch/llm_server.py
+++ b/rollout_elastic/patch/llm_server.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 """Patch ``verl.workers.rollout.llm_server`` for elastic inference.
 
-This area extends the four native classes of ``llm_server.py``:
+This area replaces the LB actor and extends the native client/manager classes:
 
-- ``GlobalRequestLoadBalancer`` (Ray actor): rewritten as a thin forwarder over
+- ``ElasticGlobalRequestLoadBalancer`` (recipe-owned Ray actor): forwards to
   the recipe-owned ``_LoadBalancerCore`` state machine (kept in
   ``fault_tolerance.load_balancer``), which adds fault tolerance
   (``mark_failed``, dead-set routing) and real ``add_servers`` /
@@ -29,9 +29,9 @@ This area extends the four native classes of ``llm_server.py``:
   ``RolloutProgressStoreActor``, and can spawn replacement replicas
   (``spawn_replacement`` / ``_reclaim_ray_resources``).
 
-``_LoadBalancerCore`` and ``RetryLLMServerClient`` are brand-new classes and are
-kept as recipe files under ``fault_tolerance``; everything else is expressed as
-decorators against the native classes.
+The LB actor is defined completely before Ray decorates it. The core and retry
+client live under ``fault_tolerance``; native clients and the manager are extended
+through decorators.
 """
 
 from __future__ import annotations
@@ -52,7 +52,6 @@ from verl.utils.tokenizer import normalize_token_ids
 from verl.workers.rollout.llm_server import (
     DEFAULT_ROUTING_CACHE_SIZE,
     FullyLLMServerClient,
-    GlobalRequestLoadBalancer,
     LLMServerClient,
     LLMServerManager,
 )
@@ -62,84 +61,66 @@ from ._core import add, patch, wrap
 
 logger = logging.getLogger(__name__)
 
+
+def _read_ft_enabled(config: Any) -> bool:
+    """Read the FT master switch; missing config keys mean disabled."""
+    try:
+        return bool(config.async_training.fault_tolerance.enabled)
+    except (AttributeError, KeyError):
+        return False
+
+
 # ---------------------------------------------------------------------------
-# GlobalRequestLoadBalancer (Ray actor) — thin forwarder over _LoadBalancerCore
+# Recipe-owned LB actor — all methods are defined before Ray wraps the class
 # ---------------------------------------------------------------------------
 
-_ORIG_LB = "_rollout_elastic_lb_core"
 
+@ray.remote
+class ElasticGlobalRequestLoadBalancer:
+    """Global routing and fault state shared by all recipe clients."""
 
-@wrap(GlobalRequestLoadBalancer, "__init__")
-def _lb_init(
-    orig,
-    self,
-    servers: dict[str, ray.actor.ActorHandle],
-    max_cache_size: int = DEFAULT_ROUTING_CACHE_SIZE,
-    enable_fault_tolerance: bool = False,
-):
-    """Initialize the LB around the recipe-owned ``_LoadBalancerCore``."""
-    from verl.workers.rollout.fault_tolerance.load_balancer import _LoadBalancerCore
-
-    orig(self, servers, max_cache_size=max_cache_size)
-    self._core = _LoadBalancerCore(
-        servers=servers,
-        max_cache_size=max_cache_size,
-        enable_fault_tolerance=enable_fault_tolerance,
-    )
-    setattr(self, _ORIG_LB, True)
-
-
-def _lb_core(self):
-    core = getattr(self, _ORIG_LB, None)
-    if core is None:
-        # Safety net for actors constructed before the patch was installed.
+    def __init__(
+        self,
+        servers: dict[str, ray.actor.ActorHandle],
+        max_cache_size: int = DEFAULT_ROUTING_CACHE_SIZE,
+        enable_fault_tolerance: bool = False,
+    ) -> None:
         from verl.workers.rollout.fault_tolerance.load_balancer import _LoadBalancerCore
 
-        core = _LoadBalancerCore(servers=self._server)
-        setattr(self, _ORIG_LB, core)
-    return core
+        self._core = _LoadBalancerCore(
+            servers=servers,
+            max_cache_size=max_cache_size,
+            enable_fault_tolerance=enable_fault_tolerance,
+        )
+        logger.warning(
+            "[FT] Elastic LB initialized: pid=%s host=%s servers=%s ft=%s",
+            os.getpid(),
+            socket.gethostname(),
+            list(servers),
+            enable_fault_tolerance,
+        )
 
+    def acquire_server(self, request_id: str) -> str:
+        return self._core.acquire_server(request_id)
 
-@patch(GlobalRequestLoadBalancer, "acquire_server")
-def acquire_server(self, request_id: str) -> str:
-    """Acquire a server for the given request, skipping dead servers."""
-    return _lb_core(self).acquire_server(request_id)
+    def release_server(self, server_id: str) -> None:
+        self._core.release_server(server_id)
 
+    def mark_failed(self, server_id: str) -> None:
+        self._core.mark_failed(server_id)
+        logger.warning("[FT] Elastic LB mark_failed completed: server_id=%s", server_id)
 
-@patch(GlobalRequestLoadBalancer, "release_server")
-def release_server(self, server_id: str) -> None:
-    """Release a server after a request completes, decrementing its inflight count."""
-    _lb_core(self).release_server(server_id)
+    def set_fault_tolerance(self, enabled: bool) -> None:
+        self._core.set_fault_tolerance(enabled)
 
+    def add_servers(self, servers: dict[str, ray.actor.ActorHandle]) -> None:
+        self._core.add_servers(servers)
 
-@add(GlobalRequestLoadBalancer, "mark_failed")
-def mark_failed(self, server_id: str) -> None:
-    """Mark a server as dead; subsequent acquires skip it. Idempotent."""
-    _lb_core(self).mark_failed(server_id)
+    def remove_servers(self, server_ids: list[str]) -> None:
+        self._core.remove_servers(server_ids)
 
-
-@add(GlobalRequestLoadBalancer, "set_fault_tolerance")
-def set_fault_tolerance(self, enabled: bool) -> None:
-    """Enable or disable fault tolerance for the load balancer."""
-    _lb_core(self)._ft = bool(enabled)
-
-
-@patch(GlobalRequestLoadBalancer, "add_servers")
-def add_servers(self, servers: dict[str, ray.actor.ActorHandle]) -> None:
-    """Add new servers to the server handles. Idempotent; resurrects dead ids."""
-    _lb_core(self).add_servers(servers)
-
-
-@patch(GlobalRequestLoadBalancer, "remove_servers")
-def remove_servers(self, server_ids: list[str]) -> None:
-    """Remove servers from the server handles."""
-    _lb_core(self).remove_servers(server_ids)
-
-
-@add(GlobalRequestLoadBalancer, "get_server_handle")
-def get_server_handle(self, server_id: str):
-    """Return the Ray actor handle for ``server_id``, or None if unknown."""
-    return _lb_core(self).get_server_handle(server_id)
+    def get_server_handle(self, server_id: str):
+        return self._core.get_server_handle(server_id)
 
 
 # ---------------------------------------------------------------------------
@@ -168,10 +149,7 @@ def _client_init(
 @add(LLMServerClient, "_ft_enabled")
 def _ft_enabled(self) -> bool:
     """Whether the fault-tolerance master switch is on for this config."""
-    try:
-        return bool(self.config.async_training.fault_tolerance.enabled)
-    except (AttributeError, KeyError):
-        return False
+    return _read_ft_enabled(self.config)
 
 
 @add(LLMServerClient, "_ft_call_timeout_s")
@@ -276,6 +254,9 @@ async def _generate_once(
 
 @patch(LLMServerClient, "_acquire_server")
 async def _acquire_server(self, request_id: str) -> tuple[str, ray.actor.ActorHandle]:
+    if not self._ft_enabled():
+        return await self._orig__acquire_server(request_id)
+
     server_id = await self._load_balancer.acquire_server.remote(request_id=request_id)
     handle = self._server_id_to_handle.get(server_id)
     if handle is None:
@@ -289,6 +270,9 @@ async def _acquire_server(self, request_id: str) -> tuple[str, ray.actor.ActorHa
 
 @patch(LLMServerClient, "_release_server")
 def _release_server(self, server_id: str) -> None:
+    if not self._ft_enabled():
+        return self._orig__release_server(server_id)
+
     # Fire-and-forget: release is just a counter decrement, no need to await.
     # Awaiting here risks blocking the finally clause if the LB actor is unresponsive.
     try:
@@ -300,11 +284,14 @@ def _release_server(self, server_id: str) -> None:
 
 @add(LLMServerClient, "_mark_server_failed")
 async def _mark_server_failed(self, server_id: str) -> None:
-    """Fire-and-forget notify LB that a server is dead. Must never block."""
+    """Notify LB with a bounded wait; log failures without propagating them."""
+    if not self._ft_enabled():
+        return
+
     try:
         await asyncio.wait_for(self._load_balancer.mark_failed.remote(server_id=server_id), timeout=3.0)
     except Exception:
-        logger.warning("[FT] _mark_server_failed: mark server %s failed", server_id)
+        logger.exception("[FT] LB mark_failed RPC failed: server_id=%s", server_id)
 
 
 @patch(LLMServerClient, "generate")
@@ -654,19 +641,35 @@ async def _init_progress_store(self, progress_cfg) -> None:
     await self._progress_store.init.remote(progress_cfg)
 
 
+@add(LLMServerManager, "_ft_enabled")
+def _manager_ft_enabled(self) -> bool:
+    """Select the LB and client implementation from the same master switch."""
+    return _read_ft_enabled(self.config)
+
+
 @patch(LLMServerManager, "_init_global_load_balancer")
 async def _init_global_load_balancer(self) -> None:
-    ft_on = False
+    if not self._ft_enabled():
+        await self._orig__init_global_load_balancer()
+        return
+
     try:
-        ft_on = bool(self.config.async_training.fault_tolerance.enabled)
-    except (AttributeError, KeyError):
-        pass
-    self.global_load_balancer = GlobalRequestLoadBalancer.remote(
+        from ray.util.scheduling_strategies import NodeAffinitySchedulingStrategy
+
+        node_id = ray.get_runtime_context().get_node_id()
+        scheduling_strategy = NodeAffinitySchedulingStrategy(node_id=node_id, soft=True)
+    except Exception:
+        scheduling_strategy = None
+    options: dict[str, Any] = {"max_restarts": 3, "max_task_retries": 3}
+    if scheduling_strategy is not None:
+        options["scheduling_strategy"] = scheduling_strategy
+    self.global_load_balancer = ElasticGlobalRequestLoadBalancer.options(**options).remote(
         servers=dict(zip(self.server_addresses, self.server_handles, strict=True)),
         max_cache_size=DEFAULT_ROUTING_CACHE_SIZE,
+        enable_fault_tolerance=True,
     )
-    if ft_on:
-        await self.global_load_balancer.set_fault_tolerance.remote(True)
+    # Surface actor initialization failures before returning the manager.
+    await self.global_load_balancer.set_fault_tolerance.remote(True)
 
 
 @patch(LLMServerManager, "get_client")
@@ -675,8 +678,11 @@ def get_client(self, fully_async: bool = False, retry: bool = False) -> LLMServe
 
     Args:
         fully_async (bool): Whether to return the FullyLLMServerClient.
-        retry (bool): Whether to retry on server unavailability.
+        retry (bool): Whether to retry on server unavailability when FT is enabled.
     """
+    if not self._ft_enabled():
+        return self._orig_get_client(fully_async=fully_async)
+
     servers = dict(zip(self.server_addresses, self.server_handles, strict=True))
     common = dict(
         config=self.config,

--- a/rollout_elastic/workers/rollout/fault_tolerance/load_balancer.py
+++ b/rollout_elastic/workers/rollout/fault_tolerance/load_balancer.py
@@ -14,8 +14,8 @@
 """Plain-Python load-balancer state machine for elastic rollout.
 
 ``_LoadBalancerCore`` is a new class kept in the recipe (it does not exist in
-verl@dfc01f85). It is wrapped by verl's native ``GlobalRequestLoadBalancer``
-Ray actor via the ``patch.llm_server`` decorators, so the state machine is
+verl@dfc01f85). It is wrapped by the recipe-owned ``ElasticGlobalRequestLoadBalancer``
+Ray actor defined in ``patch.llm_server``, so the state machine is
 unit-testable without ``ray.init()``.
 """
 
@@ -29,7 +29,7 @@ DEFAULT_ROUTING_CACHE_SIZE = 10000
 class _LoadBalancerCore:
     """Plain-Python state machine for load balancing.
 
-    Wrapped by `GlobalRequestLoadBalancer` (Ray actor) for remote access.
+    Wrapped by `ElasticGlobalRequestLoadBalancer` (Ray actor) for remote access.
     Splitting the logic from the Ray decorator makes it unit-testable without
     `ray.init()`, while keeping the Ray actor as a thin forwarder.
 
@@ -104,6 +104,10 @@ class _LoadBalancerCore:
         if server_id in self._server or server_id in self._inflight:
             self._dead.add(server_id)
         # If server_id is unknown entirely, silently no-op (idempotent on unknown ids).
+
+    def set_fault_tolerance(self, enabled: bool) -> None:
+        """Toggle fault-tolerant semantics (lenient release, dead-set routing)."""
+        self._ft = bool(enabled)
 
     def add_servers(self, servers: dict) -> None:
         """Register new servers. Idempotent on existing ids. Resurrect dead ids."""


### PR DESCRIPTION
Runtime decorator patches on the native GlobalRequestLoadBalancer actor never reached the Ray worker process: Ray loads the actor class by module name (local import or by-reference cloudpickle), so driver-side setattr changes are silently dropped and acquire_server/mark_failed ran the bare native code. Ship a fully defined, recipe-owned ElasticGlobalRequestLoadBalancer instead (patch-as-source), gate the recipe path behind the fault_tolerance.enabled switch so FT-off keeps the native LB and client, register patched methods in Ray actor metadata (ignore_first typo), and add LB actor restart protection. Covered by end-to-end RPC tests over the patched manager/client paths.